### PR TITLE
v2alpha -> v2beta

### DIFF
--- a/src/api/getFetchAll.ts
+++ b/src/api/getFetchAll.ts
@@ -1,13 +1,13 @@
-type FetchChunkFn<Arg, Res> = (
+type FetchChunkFn<Arg, Res extends T[] | Record<string, T>, T> = (
   rpc: string,
   arg: Arg,
   limit: number,
   offset: number
-) => Promise<Res[]>;
+) => Promise<Res>;
 type FetchAllFn<Arg, Res> = (rpc: string, arg: Arg) => Promise<Res[]>;
 
-const getFetchAll = <Arg, Res>(
-  fn: FetchChunkFn<Arg, Res>,
+const getFetchAll = <Arg, Res extends T[] | Record<string, T>, T>(
+  fn: FetchChunkFn<Arg, Res, T>,
   perPage = 100,
   maxCycles = 10
 ): FetchAllFn<Arg, Res> => {
@@ -16,11 +16,27 @@ const getFetchAll = <Arg, Res>(
     rpc: string,
     arg: Arg,
     page: number
-  ): Promise<Res[]> => {
+  ): Promise<Res> => {
     const res = await fn(rpc, arg, perPage, page * perPage);
-    if (res.length === 100 && cycle < maxCycles) {
+
+    // Fetch and merge arrays
+    if (Array.isArray(res) && res.length === 100 && cycle < maxCycles) {
       cycle += 1;
-      return [...res, ...(await fetchNextChunk(rpc, arg, page + 1))];
+      const merged: T[] = [
+        ...res,
+        ...((await fetchNextChunk(rpc, arg, page + 1)) as T[]),
+      ];
+      return merged as Res;
+    }
+
+    // Fetch and merge records
+    if (Object.keys(res).length === 100 && cycle < maxCycles) {
+      cycle += 1;
+      const merged = {
+        ...(res as Record<string, T>),
+        ...((await fetchNextChunk(rpc, arg, page + 1)) as Record<string, T>),
+      };
+      return merged as Res;
     }
     return res;
   };

--- a/src/api/requests/eligibilities.ts
+++ b/src/api/requests/eligibilities.ts
@@ -5,9 +5,9 @@ import { parseResponse } from '../schemas/error';
 // eslint-disable-next-line import/prefer-default-export
 export const fetchEligibilities = (rpc: string) =>
   fetchJSON(
-    `${rpc}/spacemesh.v2alpha1.SmeshingIdentitiesService/Eligibilities`,
+    `${rpc}/spacemesh.v2beta1.SmeshingIdentitiesService/Eligibilities`,
     {
-      method: 'POST',
+      method: 'GET',
     }
   )
     .then(parseResponse(EligibilitiesResponseSchema))

--- a/src/api/requests/netinfo.ts
+++ b/src/api/requests/netinfo.ts
@@ -20,7 +20,7 @@ export const fetchNetworkInfo = (rpc: string) =>
     }));
 
 export const fetchNodeStatus = (rpc: string) =>
-  fetchJSON(`${rpc}/spacemesh.v2beta1.NodeService/Status`, { method: 'POST' })
+  fetchJSON(`${rpc}/spacemesh.v2beta1.NodeService/Status`, { method: 'GET' })
     .then(parseResponse(NodeStatusSchema))
     .then((status) => ({
       connectedPeers: parseInt(status.connectedPeers, 10),

--- a/src/api/requests/netinfo.ts
+++ b/src/api/requests/netinfo.ts
@@ -8,8 +8,8 @@ import { NetworkInfoResponseSchema } from '../schemas/network';
 import { NodeStatusSchema, NodeSyncStatus } from '../schemas/node';
 
 export const fetchNetworkInfo = (rpc: string) =>
-  fetchJSON(`${rpc}/spacemesh.v2alpha1.NetworkService/Info`, {
-    method: 'POST',
+  fetchJSON(`${rpc}/spacemesh.v2beta1.NetworkService/Info`, {
+    method: 'GET',
   })
     .then(parseResponse(NetworkInfoResponseSchema))
     .then((res) => ({
@@ -20,7 +20,7 @@ export const fetchNetworkInfo = (rpc: string) =>
     }));
 
 export const fetchNodeStatus = (rpc: string) =>
-  fetchJSON(`${rpc}/spacemesh.v2alpha1.NodeService/Status`, { method: 'POST' })
+  fetchJSON(`${rpc}/spacemesh.v2beta1.NodeService/Status`, { method: 'POST' })
     .then(parseResponse(NodeStatusSchema))
     .then((status) => ({
       connectedPeers: parseInt(status.connectedPeers, 10),

--- a/src/api/requests/poets.ts
+++ b/src/api/requests/poets.ts
@@ -6,8 +6,8 @@ import { PoETInfoResponseSchema } from '../schemas/poets';
 
 // eslint-disable-next-line import/prefer-default-export
 export const fetchPoETInfo = (rpc: string) =>
-  fetchJSON(`${rpc}/spacemesh.v2alpha1.SmeshingIdentitiesService/PoetInfo`, {
-    method: 'POST',
+  fetchJSON(`${rpc}/spacemesh.v2beta1.SmeshingIdentitiesService/PoetInfo`, {
+    method: 'GET',
   })
     .then(parseResponse(PoETInfoResponseSchema))
     .then((res) => ({

--- a/src/api/requests/proposals.ts
+++ b/src/api/requests/proposals.ts
@@ -4,8 +4,8 @@ import { ProposalsResponseSchema } from '../schemas/proposals';
 
 // eslint-disable-next-line import/prefer-default-export
 export const fetchProposals = (rpc: string) =>
-  fetchJSON(`${rpc}/spacemesh.v2alpha1.SmeshingIdentitiesService/Proposals`, {
-    method: 'POST',
+  fetchJSON(`${rpc}/spacemesh.v2beta1.SmeshingIdentitiesService/Proposals`, {
+    method: 'GET',
   })
     .then(parseResponse(ProposalsResponseSchema))
     .then((res) => res.proposals);

--- a/src/api/requests/smesherState.ts
+++ b/src/api/requests/smesherState.ts
@@ -1,10 +1,18 @@
 import fetchJSON from '../../utils/fetchJSON';
+import getFetchAll from '../getFetchAll';
 import { parseResponse } from '../schemas/error';
 import { SmesherStatesResponseSchema } from '../schemas/smesherStates';
 
-// eslint-disable-next-line import/prefer-default-export
-export const fetchSmesherStates = (rpc: string, limit = 100) => {
-  const params = new URLSearchParams({ limit: limit.toString() });
+const fetchSmesherStatesChunk = (
+  rpc: string,
+  limit: number,
+  offset: number
+) => {
+  const params = new URLSearchParams({
+    limit: limit.toString(),
+    offset: offset.toString(),
+  });
+
   return fetchJSON(
     `${rpc}/spacemesh.v2beta1.SmeshingIdentitiesService/States?${params}`,
     {
@@ -14,3 +22,9 @@ export const fetchSmesherStates = (rpc: string, limit = 100) => {
     .then(parseResponse(SmesherStatesResponseSchema))
     .then((res) => res.identities);
 };
+
+export const fetchSmesherStates = getFetchAll((rpc, _, limit, offset) =>
+  fetchSmesherStatesChunk(rpc, limit, offset)
+);
+
+export default fetchSmesherStates;

--- a/src/api/requests/smesherState.ts
+++ b/src/api/requests/smesherState.ts
@@ -3,9 +3,14 @@ import { parseResponse } from '../schemas/error';
 import { SmesherStatesResponseSchema } from '../schemas/smesherStates';
 
 // eslint-disable-next-line import/prefer-default-export
-export const fetchSmesherStates = (rpc: string) =>
-  fetchJSON(`${rpc}/spacemesh.v2alpha1.SmeshingIdentitiesService/States`, {
-    method: 'POST',
-  })
+export const fetchSmesherStates = (rpc: string, limit = 100) => {
+  const params = new URLSearchParams({ limit: limit.toString() });
+  return fetchJSON(
+    `${rpc}/spacemesh.v2beta1.SmeshingIdentitiesService/States?${params}`,
+    {
+      method: 'GET',
+    }
+  )
     .then(parseResponse(SmesherStatesResponseSchema))
     .then((res) => res.identities);
+};


### PR DESCRIPTION
In the `node-split-poc` in go-sm we moved to v2beta1 apis, post requests without params are now GET. We need remote node upgrade for that.

For now WIP as this is untested.