### PR TITLE
Tweak GUI for events data

### DIFF
--- a/src/api/getFetchAll.ts
+++ b/src/api/getFetchAll.ts
@@ -9,23 +9,23 @@ type FetchAllFn<Arg, Res> = (rpc: string, arg: Arg) => Promise<Res[]>;
 const getFetchAll = <Arg, Res>(
   fn: FetchChunkFn<Arg, Res>,
   perPage = 100,
-  maxCycles = 10
+  maxCycles = Infinity
 ): FetchAllFn<Arg, Res> => {
   let cycle = 1;
-  const fetchNextChunk = async (
-    rpc: string,
-    arg: Arg,
-    page: number
-  ): Promise<Res[]> => {
-    const res = await fn(rpc, arg, perPage, page * perPage);
+  const prevOffset: Record<string, number> = {};
+  const fetchNextChunk = async (rpc: string, arg: Arg): Promise<Res[]> => {
+    const key = JSON.stringify(arg);
+    const curOffset = prevOffset[key] ?? 0;
+    const res = await fn(rpc, arg, perPage, curOffset);
+    prevOffset[key] = curOffset + res.length;
     if (res.length === 100 && cycle < maxCycles) {
       cycle += 1;
-      return [...res, ...(await fetchNextChunk(rpc, arg, page + 1))];
+      return [...res, ...(await fetchNextChunk(rpc, arg))];
     }
     return res;
   };
 
-  return (rpc: string, arg: Arg) => fetchNextChunk(rpc, arg, 0);
+  return (rpc: string, arg: Arg) => fetchNextChunk(rpc, arg);
 };
 
 export default getFetchAll;

--- a/src/api/requests/activations.ts
+++ b/src/api/requests/activations.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import fetchJSON from '../../utils/fetchJSON';
+import { parseResponse } from '../schemas/error';
+
+// eslint-disable-next-line import/prefer-default-export
+export const fetchActivationsCount = (rpc: string) =>
+  fetchJSON(`${rpc}/spacemesh.v2beta1.ActivationService/ActivationsCount`, {
+    method: 'GET',
+  })
+    .then(parseResponse(z.object({ count: z.number() })))
+    .then((res) => res.count);

--- a/src/api/requests/smesherState.ts
+++ b/src/api/requests/smesherState.ts
@@ -1,10 +1,21 @@
 import fetchJSON from '../../utils/fetchJSON';
 import { parseResponse } from '../schemas/error';
-import { SmesherStatesResponseSchema } from '../schemas/smesherStates';
+import {
+  IdentityStateInfo,
+  SmesherStatesResponseSchema,
+} from '../schemas/smesherStates';
 
-// eslint-disable-next-line import/prefer-default-export
-export const fetchSmesherStates = (rpc: string, limit = 100) => {
-  const params = new URLSearchParams({ limit: limit.toString() });
+const PER_PAGE = 100;
+
+export const fetchSmesherStatesChunk = (
+  rpc: string,
+  limit = PER_PAGE,
+  offset = 0
+) => {
+  const params = new URLSearchParams({
+    limit: limit.toString(),
+    offset: offset.toString(),
+  });
   return fetchJSON(
     `${rpc}/spacemesh.v2beta1.SmeshingIdentitiesService/States?${params}`,
     {
@@ -13,4 +24,41 @@ export const fetchSmesherStates = (rpc: string, limit = 100) => {
   )
     .then(parseResponse(SmesherStatesResponseSchema))
     .then((res) => res.identities);
+};
+
+type SmesherStates = Record<string, { history: IdentityStateInfo[] }>;
+
+const mergeSmesherStates = (
+  obj1: SmesherStates,
+  obj2: SmesherStates
+): SmesherStates =>
+  Object.keys(obj2).reduce(
+    (acc, key) => {
+      const history = [
+        ...(acc[key]?.history ?? []),
+        ...(obj2[key]?.history ?? []),
+      ];
+      return {
+        ...acc,
+        [key]: {
+          ...acc[key],
+          ...obj2[key],
+          history,
+        },
+      };
+    },
+    { ...obj1 }
+  );
+
+export const fetchSmesherStates = async (rpc: string) => {
+  const fetchNext = async (page: number): Promise<SmesherStates> => {
+    const res = await fetchSmesherStatesChunk(rpc, PER_PAGE, page * PER_PAGE);
+    if (Object.values(res).flatMap((x) => x.history).length === PER_PAGE) {
+      const next = await fetchNext(page + 1);
+      return mergeSmesherStates(res, next);
+    }
+    return res;
+  };
+
+  return fetchNext(0);
 };

--- a/src/api/schemas/smesherEvents.ts
+++ b/src/api/schemas/smesherEvents.ts
@@ -33,21 +33,18 @@ export enum EventName {
 
 const BaseEventSchema = <K extends EventName>(eventName: K) =>
   z.object({
+    smesher: Base64Schema,
     state: z.literal(eventName),
     publishEpoch: z.optional(z.number()),
     time: z.string().datetime(),
   });
 
+type BaseEvent<K extends EventName> = ReturnType<typeof BaseEventSchema<K>>;
+
 function SmesherHistoryItem<T extends z.ZodRawShape>(
   state: EventName,
   detailsSchema: z.ZodObject<T>
-): z.ZodObject<
-  {
-    state: z.ZodLiteral<EventName>;
-    publishEpoch?: z.ZodOptional<z.ZodNumber>;
-    time: z.ZodString;
-  } & T
-> {
+): z.ZodObject<BaseEvent<EventName>['shape'] & T> {
   const baseSchema = BaseEventSchema(state);
   return z.object({
     ...baseSchema.shape,

--- a/src/api/schemas/smesherStates.ts
+++ b/src/api/schemas/smesherStates.ts
@@ -23,14 +23,6 @@ export const SmesherHistoryItemSchema = z.discriminatedUnion('state', [
 
 export type IdentityStateInfo = z.infer<typeof SmesherHistoryItemSchema>;
 
-export const SmesherIdentitiesSchema = z.record(
-  z.object({
-    history: z.array(SmesherHistoryItemSchema),
-  })
-);
-
-export type SmesherIdentities = z.infer<typeof SmesherIdentitiesSchema>;
-
 export const SmesherStatesResponseSchema = z.object({
-  identities: SmesherIdentitiesSchema,
+  states: z.array(SmesherHistoryItemSchema),
 });

--- a/src/api/sortOrder.ts
+++ b/src/api/sortOrder.ts
@@ -1,0 +1,6 @@
+enum SortOrder {
+  ASC = 0,
+  DESC = 1,
+}
+
+export default SortOrder;

--- a/src/components/dashboard/NetworkInfo.tsx
+++ b/src/components/dashboard/NetworkInfo.tsx
@@ -1,0 +1,38 @@
+import humanizeDuration from 'humanize-duration';
+
+import { Code, Table, TableContainer } from '@chakra-ui/react';
+
+import { Network } from '../../types/networks';
+import { SECOND } from '../../utils/constants';
+import { formatTimestamp } from '../../utils/datetime';
+import TableContents from '../basic/TableContents';
+
+function NetworkInfo({ data }: { data: Network }): JSX.Element {
+  return (
+    <TableContainer>
+      <Table size="sm" variant="unstyled">
+        <TableContents
+          tableKey="netInfo"
+          tdProps={{
+            _first: { pl: 0, w: '30%' },
+            _last: { pr: 0 },
+          }}
+          data={[
+            ['Genesis Time', formatTimestamp(data.genesisTime || 0)],
+            [
+              'Genesis ID',
+              <Code display="inline" wordBreak="break-all" whiteSpace="normal">
+                {data.genesisId}
+              </Code>,
+            ],
+            ['Layer duration', humanizeDuration(data.layerDuration * SECOND)],
+            ['Layers per epoch', data.layersPerEpoch],
+            ['Effective genesis', data.effectiveGenesisLayer],
+          ]}
+        />
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default NetworkInfo;

--- a/src/components/dashboard/NodeStatusInfo.tsx
+++ b/src/components/dashboard/NodeStatusInfo.tsx
@@ -1,0 +1,45 @@
+import { Table, TableContainer } from '@chakra-ui/react';
+
+import { Activations, NodeStatus } from '../../types/networks';
+import TableContents from '../basic/TableContents';
+
+function NodeStatusInfo({
+  node,
+  activations,
+}: {
+  node: NodeStatus;
+  activations: Activations | null;
+}): JSX.Element {
+  return (
+    <TableContainer>
+      <Table size="sm" variant="unstyled">
+        <TableContents
+          tableKey="netInfo"
+          tdProps={{
+            _first: { pl: 0, w: '30%' },
+            _last: { pr: 0 },
+          }}
+          data={[
+            ['Sync status', node.isSynced ? 'Synced' : 'Not synced'],
+            [
+              'Processed layer',
+              // eslint-disable-next-line max-len
+              `${node.processedLayer} / ${node.currentLayer}`,
+            ],
+            ['Applied layer', node.appliedLayer],
+            ['Latest layer', node.latestLayer],
+            ['Connected peers', node.connectedPeers],
+            [
+              'Activations',
+              activations === null
+                ? 'Loading...'
+                : activations.count.toString(),
+            ],
+          ]}
+        />
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default NodeStatusInfo;

--- a/src/components/dashboard/OptionalError.tsx
+++ b/src/components/dashboard/OptionalError.tsx
@@ -1,0 +1,20 @@
+import { Text } from '@chakra-ui/react';
+
+function OptionalError({
+  store,
+  prefix = '',
+}: {
+  store: { error: Error | null };
+  prefix?: string;
+}) {
+  if (!store.error) return null;
+
+  return (
+    <Text color="red.500">
+      {prefix}
+      {store.error.message}
+    </Text>
+  );
+}
+
+export default OptionalError;

--- a/src/components/dashboard/SmesherIdentityDetails.tsx
+++ b/src/components/dashboard/SmesherIdentityDetails.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react';
+
+import { Box, Flex, Heading, Tag, Text, Tooltip } from '@chakra-ui/react';
+
+import { ElibigilitiesByIdentity } from '../../api/schemas/eligibilities';
+import { ProposalsByIdentity } from '../../api/schemas/proposals';
+import { HexString } from '../../types/common';
+import { RewardsPerIdentity } from '../../types/reward';
+import { formatSmidge } from '../../utils/smh';
+
+type Props = {
+  id: HexString;
+  eligibilities?: ElibigilitiesByIdentity[HexString]['epochs'];
+  proposals?: ProposalsByIdentity[HexString]['proposals'];
+  rewards?: RewardsPerIdentity[HexString];
+  currentLayer?: number;
+};
+
+function SmesherIdentityDetails({
+  id,
+  eligibilities = {},
+  proposals = [],
+  rewards = [],
+  currentLayer = 0,
+}: Props): JSX.Element {
+  const proposalLayers = useMemo(
+    () => new Set(proposals.map((proposal) => proposal.layer)),
+    [proposals]
+  );
+
+  return (
+    <Flex w="100%" justifyContent="space-between" mb={2}>
+      <Box w="55%">
+        <Heading fontSize="sm">Eligibilities</Heading>
+        {Object.entries(eligibilities).map(
+          ([epoch, { eligibilities: epochEligibilities }]) => (
+            <Box
+              key={`Eligibilities_${id}_${epoch}`}
+              my={2}
+              p={3}
+              borderWidth={1}
+              borderStyle="solid"
+              borderColor="brand.darkGray"
+              borderRadius="lg"
+            >
+              <Text fontSize="sm">Epoch {epoch}</Text>
+              <Text fontSize="xs" color="gray.500" mt={1} mb={0.5}>
+                Layers
+              </Text>
+              <Box lineHeight={0}>
+                {epochEligibilities
+                  .sort((a, b) => a.layer - b.layer)
+                  .map((el) => (
+                    <Tooltip
+                      label={
+                        <>
+                          <Text fontSize="xs">Layer: {el.layer}</Text>
+                          <Text fontSize="xs" mb={1}>
+                            Weight: {el.count}
+                          </Text>
+                          {proposalLayers.has(el.layer) && (
+                            <Text color="brand.darkGreen" fontSize="xs">
+                              Published:{' '}
+                              {proposals.find((p) => p.layer === el.layer)
+                                ?.proposal ?? ''}
+                            </Text>
+                          )}
+                        </>
+                      }
+                      // eslint-disable-next-line max-len
+                      key={`elig_${id}_${epoch}_${el.layer}`}
+                    >
+                      <Tag
+                        size="sm"
+                        mr={0.5}
+                        mb={0.5}
+                        // eslint-disable-next-line max-len
+                        // eslint-disable-next-line no-nested-ternary
+                        {...(proposalLayers.has(el.layer)
+                          ? { colorScheme: 'green' }
+                          : currentLayer > el.layer
+                          ? { colorScheme: 'red' }
+                          : { colorScheme: 'yellow' })}
+                      >
+                        {el.layer}
+                      </Tag>
+                    </Tooltip>
+                  ))}
+              </Box>
+            </Box>
+          )
+        )}
+        {Object.keys(eligibilities).length === 0 && (
+          <Text fontSize="sm" color="gray.500">
+            No eligible epochs and layers yet
+          </Text>
+        )}
+      </Box>
+      <Box w="40%">
+        <Heading fontSize="sm">Rewards</Heading>
+        {rewards.map((reward) => (
+          <Box
+            // eslint-disable-next-line max-len
+            key={`Reward${id}_${reward.layerPaid}_${reward.smesher}`}
+            my={2}
+            p={3}
+            borderWidth={1}
+            borderStyle="solid"
+            borderColor="brand.darkGray"
+            borderRadius="lg"
+          >
+            <Text fontSize="sm" color="brand.green">
+              +{formatSmidge(reward.rewardForLayer + reward.rewardForFees)}
+            </Text>
+            <Text fontSize="xs" color="gray.500" mt={1} mb={0.5}>
+              To: {reward.coinbase}
+            </Text>
+          </Box>
+        ))}
+        {rewards.length === 0 && (
+          <Text fontSize="sm" color="gray.500">
+            No rewards yet
+          </Text>
+        )}
+      </Box>
+    </Flex>
+  );
+}
+
+export default SmesherIdentityDetails;

--- a/src/components/dashboard/SmesherIdentityDetails.tsx
+++ b/src/components/dashboard/SmesherIdentityDetails.tsx
@@ -32,8 +32,9 @@ function SmesherIdentityDetails({
     <Flex w="100%" justifyContent="space-between" mb={2}>
       <Box w="55%">
         <Heading fontSize="sm">Eligibilities</Heading>
-        {Object.entries(eligibilities).map(
-          ([epoch, { eligibilities: epochEligibilities }]) => (
+        {Object.entries(eligibilities)
+          .sort(([a], [b]) => parseInt(b, 10) - parseInt(a, 10))
+          .map(([epoch, { eligibilities: epochEligibilities }]) => (
             <Box
               key={`Eligibilities_${id}_${epoch}`}
               my={2}
@@ -88,8 +89,7 @@ function SmesherIdentityDetails({
                   ))}
               </Box>
             </Box>
-          )
-        )}
+          ))}
         {Object.keys(eligibilities).length === 0 && (
           <Text fontSize="sm" color="gray.500">
             No eligible epochs and layers yet

--- a/src/components/timeline/SmeshingTimeline.tsx
+++ b/src/components/timeline/SmeshingTimeline.tsx
@@ -46,9 +46,10 @@ const getGroups = ({
         : undefined,
   },
   ...smesherIds.map(
-    (id): TimelineGroup => ({
+    (id, idx): TimelineGroup => ({
       id: `smesher_${id}`,
       content: getAbbreviatedHexString(id),
+      visible: idx === 1,
     })
   ),
 ];

--- a/src/components/timeline/SmeshingTimeline.tsx
+++ b/src/components/timeline/SmeshingTimeline.tsx
@@ -39,17 +39,16 @@ const getGroups = ({
   {
     id: 'events',
     content: 'Events',
-    showNested: smesherIds.length > 1,
+    showNested: false,
     nestedGroups:
       smesherIds.length > 1
         ? smesherIds.sort(sortHexString).map((id) => `smesher_${id}`)
         : undefined,
   },
   ...smesherIds.map(
-    (id, idx): TimelineGroup => ({
+    (id): TimelineGroup => ({
       id: `smesher_${id}`,
       content: getAbbreviatedHexString(id),
-      visible: idx === 1,
     })
   ),
 ];

--- a/src/components/timeline/SmeshingTimeline.tsx
+++ b/src/components/timeline/SmeshingTimeline.tsx
@@ -42,7 +42,7 @@ const getGroups = ({
     showNested: smesherIds.length > 1,
     nestedGroups:
       smesherIds.length > 1
-        ? smesherIds.map((id) => `smesher_${id}`)
+        ? smesherIds.sort(sortHexString).map((id) => `smesher_${id}`)
         : undefined,
   },
   ...smesherIds.map(

--- a/src/components/timeline/SmeshingTimeline.tsx
+++ b/src/components/timeline/SmeshingTimeline.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Timeline, TimelineGroup } from 'vis-timeline';
 
-import { Box, Text, usePrevious } from '@chakra-ui/react';
+import { Box, Text, useOutsideClick, usePrevious } from '@chakra-ui/react';
 
 import useTimelineData from '../../hooks/useTimelineData';
 import { colors } from '../../theme';
@@ -207,6 +207,19 @@ export default function SmeshingTimeline() {
     y: 0,
     x: -1000,
     content: null,
+  });
+
+  useOutsideClick({
+    ref: rootRef,
+    handler: () => {
+      if (chartRef.current) {
+        setTooltip((prevState) => ({
+          ...prevState,
+          x: -1000,
+        }));
+        chartRef.current.setSelection([]);
+      }
+    },
   });
 
   useEffect(() => {

--- a/src/components/timeline/TimelineItemContent.tsx
+++ b/src/components/timeline/TimelineItemContent.tsx
@@ -1,77 +1,142 @@
 import { Box, Text } from '@chakra-ui/react';
 
 import {
+  EligibleEventDetails,
   EventName,
   PoetRegisteredEventDetails,
   ProposalBuildFailedEventDetails,
   ProposalPublishFailedEventDetails,
   RetryingEventDetails,
 } from '../../api/schemas/smesherEvents';
-import { isEventDetails, TimelineItem } from '../../types/timeline';
+import {
+  IdentityState,
+  isEpochItem,
+  isEventItem,
+  isLayerItem,
+  isPoetRoundItem,
+  isTimelineItem,
+  TimelineItem,
+  TimelineItemType,
+} from '../../types/timeline';
 
 function TimelineItemDetails({ item }: { item: TimelineItem }): JSX.Element {
-  if (!isEventDetails(item)) {
+  if (!isTimelineItem(item)) {
     return <div />;
   }
 
-  switch (item.data.details.type) {
-    case EventName.RETRYING: {
-      const details = item.data.details as RetryingEventDetails;
-      return (
-        <Text mt={2} color="brand.red">
-          {details.message}
-        </Text>
-      );
-    }
-    case EventName.PROPOSAL_PUBLISH_FAILED: {
-      const details = item.data.details as ProposalPublishFailedEventDetails;
-      return (
-        <Text mt={2} color="brand.red">
-          {details.message}
-        </Text>
-      );
-    }
-    case EventName.POET_REGISTERED: {
-      const details = item.data.details as PoetRegisteredEventDetails;
+  switch (item.data.type) {
+    case TimelineItemType.PoetRound:
+    case TimelineItemType.Layer:
+    case TimelineItemType.Epoch: {
+      if (!(isEpochItem(item) || isLayerItem(item) || isPoetRoundItem(item))) {
+        throw new Error(`Expected to have details for ${item.content}`);
+      }
+      const { details } = item.data;
       return (
         <Box mt={2}>
-          {details.registrations.map((reg) => (
-            <Text
-              key={`reg_${reg.address}_${reg.challengeHash}_${reg.roundId}`}
-              mb={1}
-            >
-              {reg.address} registered for PoET round {reg.roundId}.
-            </Text>
-          ))}
+          {Object.entries(details.identities).map(([id, state]) => {
+            const color =
+              state.state === IdentityState.FAILURE ? 'brand.red' : undefined;
+            return (
+              <Text key={id} mb={1} color={color}>
+                <strong>
+                  {id}: {state.state}
+                </strong>
+                {state.details ? (
+                  <>
+                    <br />
+                    {state.details}
+                  </>
+                ) : (
+                  ''
+                )}
+              </Text>
+            );
+          })}
         </Box>
       );
     }
-    case EventName.PROPOSAL_BUILD_FAILED: {
-      const details = item.data.details as ProposalBuildFailedEventDetails;
-      return (
-        <Box mt={2}>
-          <Text>For layer {details.layer}:</Text>
-          <Text color="brand.red">{details.message}</Text>
-        </Box>
-      );
-    }
+    case TimelineItemType.Event: {
+      if (!isEventItem(item)) {
+        throw new Error(
+          `Expected to have details for Event item: ${item.title}`
+        );
+      }
 
-    // Known events with no details (or that we don't need to show)
-    case EventName.UNSPECIFIED:
-    case EventName.WAIT_FOR_ATX_SYNCED:
-    case EventName.WAIT_FOR_POET_ROUND_END:
-    case EventName.WAITING_FOR_POET_REGISTRATION_WINDOW:
-    case EventName.POET_CHALLENGE_READY:
-    case EventName.POET_PROOF_RECEIVED:
-    case EventName.GENERATING_POST_PROOF:
-    case EventName.ATX_READY:
-    case EventName.ATX_BROADCASTED:
-    case EventName.PROPOSAL_PUBLISHED:
-    case EventName.POST_PROOF_READY:
-      return <div />;
-    // For unknown (new) events we'll show stringified details
+      switch (item.data.details.type) {
+        case EventName.RETRYING: {
+          const details = item.data.details as RetryingEventDetails;
+          return (
+            <Text mt={2} color="brand.red">
+              {details.message}
+            </Text>
+          );
+        }
+        case EventName.PROPOSAL_PUBLISH_FAILED: {
+          const details = item.data
+            .details as ProposalPublishFailedEventDetails;
+          return (
+            <Text mt={2} color="brand.red">
+              {details.message}
+            </Text>
+          );
+        }
+        case EventName.POET_REGISTERED: {
+          const details = item.data.details as PoetRegisteredEventDetails;
+          return (
+            <Box mt={2}>
+              {details.registrations.map((reg) => (
+                <Text
+                  key={`reg_${reg.address}_${reg.challengeHash}_${reg.roundId}`}
+                  mb={1}
+                >
+                  {reg.address} registered for PoET round {reg.roundId}.
+                </Text>
+              ))}
+            </Box>
+          );
+        }
+        case EventName.PROPOSAL_BUILD_FAILED: {
+          const details = item.data.details as ProposalBuildFailedEventDetails;
+          return (
+            <Box mt={2}>
+              <Text>For layer {details.layer}:</Text>
+              <Text color="brand.red">{details.message}</Text>
+            </Box>
+          );
+        }
+        case EventName.ELIGIBLE: {
+          const details = item.data.details as EligibleEventDetails;
+          return (
+            <Text mt={2}>
+              Eligible for layer{details.layers.length > 1 ? 's' : ''}:
+              <br />
+              {details.layers.map((x) => x.layer).join(', ')}
+            </Text>
+          );
+        }
+
+        // Known events with no details (or that we don't need to show)
+        case EventName.UNSPECIFIED:
+        case EventName.WAIT_FOR_ATX_SYNCED:
+        case EventName.WAIT_FOR_POET_ROUND_END:
+        case EventName.WAITING_FOR_POET_REGISTRATION_WINDOW:
+        case EventName.POET_CHALLENGE_READY:
+        case EventName.POET_PROOF_RECEIVED:
+        case EventName.GENERATING_POST_PROOF:
+        case EventName.ATX_READY:
+        case EventName.ATX_BROADCASTED:
+        case EventName.PROPOSAL_PUBLISHED:
+        case EventName.POST_PROOF_READY:
+          return <div />;
+        // For unknown (new) events we'll show stringified details
+        default:
+          return <Box mt={2}>{JSON.stringify(item.data.details, null, 2)}</Box>;
+      }
+    }
     default:
-      return <Box mt={2}>{JSON.stringify(item.data.details, null, 2)}</Box>;
+      // For unknown (new) item types just show all the data
+      return <Box mt={2}>{JSON.stringify(item.data, null, 2)}</Box>;
   }
 }
 

--- a/src/components/timeline/styles.css
+++ b/src/components/timeline/styles.css
@@ -92,6 +92,12 @@
 .epoch.failed, .layer.failed, .poet-round.failed, .cycle-gap.failed {
   background: #322525;
 }
+.epoch.rewarded, .layer.rewarded {
+  background-color: #236c31;
+}
+.epoch.eligible, .layer.eligible {
+  background-color: #585837;
+}
 
 .identities {
   display: inline-block;
@@ -131,11 +137,4 @@
 .id-marker.eligible {
   background: #FFD700;
   color: #000;
-}
-
-.layer.rewarded {
-  background-color: #236c31;
-}
-.layer.eligible {
-  background-color: #585837;
 }

--- a/src/components/timeline/styles.css
+++ b/src/components/timeline/styles.css
@@ -136,3 +136,6 @@
 .layer.rewarded {
   background-color: #236c31;
 }
+.layer.eligible {
+  background-color: #585837;
+}

--- a/src/components/timeline/styles.css
+++ b/src/components/timeline/styles.css
@@ -89,14 +89,14 @@
   border-color: transparent !important
 }
 
-.epoch.failed, .layer.failed, .poet-round.failed, .cycle-gap.failed {
+.epoch.failed, .layer.failed, .poet-round.failed {
   background: #322525;
 }
-.epoch.rewarded, .layer.rewarded {
+.epoch.rewarded, .layer.rewarded, .poet-round.success {
   background-color: #236c31;
 }
-.epoch.eligible, .layer.eligible {
-  background-color: #585837;
+.epoch.eligible, .layer.eligible, .poet-round.eligible {
+  background-color: #455532;
 }
 
 .identities {

--- a/src/hooks/useTimelineData.ts
+++ b/src/hooks/useTimelineData.ts
@@ -98,14 +98,14 @@ const useTimelineData = () => {
   const updateData = (data: TimelineItem[]) => dataSetRef.current.update(data);
 
   //
-  // Update current time once per layer
+  // Update current time twice per layer
   //
   const [currentTime, setCurrentTime] = useState(Date.now());
   useEffect(() => {
     if (netInfo) {
       const interval = setInterval(() => {
         setCurrentTime(Date.now());
-      }, netInfo.layerDuration * SECOND);
+      }, Math.floor((netInfo.layerDuration * SECOND) / 2));
       return () => clearInterval(interval);
     }
     return noop;
@@ -676,6 +676,7 @@ const useTimelineData = () => {
     }
   }, [
     currentEpoch,
+    currentTime,
     epochDuration,
     layerByTime,
     netInfo,

--- a/src/hooks/useTimelineData.ts
+++ b/src/hooks/useTimelineData.ts
@@ -76,11 +76,12 @@ type SmesherMessages = Record<HexString, SmesherMessage>;
 const useTimelineData = () => {
   const { data: netInfo } = useNetworkInfo();
   const { data: poetInfo } = usePoETInfo();
-  const { data: smesherStates } = useSmesherStates();
+  const smesherStatesStore = useSmesherStates();
   const { data: rewards } = useRewards();
   const dataSetRef = useRef(new DataSet<TimelineItem>());
   const [smesherMessages, setSmesherMessages] = useState<SmesherMessages>({});
 
+  const { data: smesherStates } = smesherStatesStore;
   const setMessage = (
     id: HexString,
     type: SmesherMessage['type'],
@@ -271,7 +272,7 @@ const useTimelineData = () => {
     () =>
       smesherEventsById
         ? Object.fromEntries(
-            smesherEventsById.map(([idx, { history }]) => [idx, history.length])
+            smesherEventsById.map(([idx, states]) => [idx, states.length])
           )
         : {},
     [smesherEventsById]
@@ -280,7 +281,7 @@ const useTimelineData = () => {
   useEffect(() => {
     if (!netInfo || !poetInfo || !smesherEventsById) return;
     const hasManyIdentities = smesherEventsById.length > 1;
-    smesherEventsById.forEach(([id, { history }]) => {
+    smesherEventsById.forEach(([id, states]) => {
       const delta =
         (smesherEventsAmountById[id] ?? 0) - (prevSmesherEventsIdx[id] ?? 0);
       const group = hasManyIdentities ? `smesher_${id}` : 'events';
@@ -292,7 +293,7 @@ const useTimelineData = () => {
 
       const updated = <TimelineItem[]>[];
 
-      history.slice(-delta).forEach((item) => {
+      states.slice(-delta).forEach((item) => {
         const details = SmesherEvents.pickSmesherEventDetails(item);
 
         // Get layer, epoch, and round numbers

--- a/src/hooks/useTimelineData.ts
+++ b/src/hooks/useTimelineData.ts
@@ -510,23 +510,62 @@ const useTimelineData = () => {
                 `poet_round_${affectedRound}`
               ) as TimelineItem<PoetRoundDetails>;
               if (round) {
-                setMessage(
-                  id,
-                  'success',
-                  // eslint-disable-next-line max-len
-                  `Registered in PoET round ${affectedRound}`
-                );
-                updated.push(
-                  updateItem(round, {
-                    className: 'poet-round eligible',
-                    identities: {
-                      [id]: {
-                        state: IdentityState.ELIGIBLE,
-                        details: 'Registered in PoET',
+                if (
+                  currentTime >
+                  getPoetRoundEnd(poetInfo.config, netInfo, affectedRound)
+                ) {
+                  setMessage(
+                    id,
+                    'failed',
+                    // eslint-disable-next-line max-len
+                    `Did not received PoET proof for round ${affectedRound} in time. Will not have rewards in epoch ${affectedEpoch}`
+                  );
+                  updated.push(
+                    updateItem(round, {
+                      className: 'poet-round failed',
+                      identities: {
+                        [id]: {
+                          state: IdentityState.FAILURE,
+                          // eslint-disable-next-line max-len
+                          details: `Did not received PoET proof for round ${affectedRound} in time`,
+                        },
                       },
-                    },
-                  })
-                );
+                    })
+                  );
+                  const epoch = getData(`epoch_${affectedEpoch}`);
+                  if (epoch) {
+                    updated.push(
+                      updateItem(epoch, {
+                        className: 'epoch failed',
+                        identities: {
+                          [id]: {
+                            state: IdentityState.FAILURE,
+                            // eslint-disable-next-line max-len
+                            details: `Did not received PoET proof for round ${affectedRound} in time`,
+                          },
+                        },
+                      })
+                    );
+                  }
+                } else {
+                  setMessage(
+                    id,
+                    'success',
+                    // eslint-disable-next-line max-len
+                    `Registered in PoET round ${affectedRound}`
+                  );
+                  updated.push(
+                    updateItem(round, {
+                      className: 'poet-round eligible',
+                      identities: {
+                        [id]: {
+                          state: IdentityState.ELIGIBLE,
+                          details: 'Registered in PoET',
+                        },
+                      },
+                    })
+                  );
+                }
               }
             }
 

--- a/src/hooks/useTimelineData.ts
+++ b/src/hooks/useTimelineData.ts
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { DataSet } from 'vis-data';
 
+import { usePrevious } from '@chakra-ui/react';
+
 import * as SmesherEvents from '../api/schemas/smesherEvents';
 import useNetworkInfo from '../store/useNetworkInfo';
 import usePoETInfo from '../store/usePoETInfo';
@@ -18,7 +20,6 @@ import {
   TimelineItemType,
 } from '../types/timeline';
 import { SECOND } from '../utils/constants';
-import { noop } from '../utils/func';
 import { formatSmidge } from '../utils/smh';
 import {
   getCycleGapEnd,
@@ -100,101 +101,124 @@ const useTimelineData = () => {
   //
   // Update current time twice per layer
   //
-  const [currentTime, setCurrentTime] = useState(Date.now());
+  const [layerByTime, setLayerByTime] = useState(0);
+  const [currentPoetRound, setCurrentPoetRound] = useState(0);
   useEffect(() => {
+    let ival: ReturnType<typeof setInterval> | null = null;
     if (netInfo) {
-      const interval = setInterval(() => {
-        setCurrentTime(Date.now());
-      }, Math.floor((netInfo.layerDuration * SECOND) / 2));
-      return () => clearInterval(interval);
+      ival = setInterval(() => {
+        setLayerByTime(
+          getLayerByTime(netInfo.layerDuration, netInfo.genesisTime, Date.now())
+        );
+        if (poetInfo) {
+          setCurrentPoetRound(
+            getPoetRoundByTime(poetInfo.config, netInfo, Date.now())
+          );
+        }
+      }, 5 * SECOND);
     }
-    return noop;
-  }, [netInfo]);
+    return () => {
+      if (ival) clearInterval(ival);
+    };
+  }, [netInfo, poetInfo]);
 
   //
   // Calculate layers and epochs
   //
-  const layerByTime = netInfo
-    ? getLayerByTime(netInfo.layerDuration, netInfo.genesisTime, currentTime)
-    : 0;
   const currentEpoch = netInfo
     ? getEpochByLayer(netInfo.layersPerEpoch, layerByTime)
     : 0;
+
   const epochDuration = netInfo
     ? getEpochDuration(netInfo.layerDuration, netInfo.layersPerEpoch)
     : 0;
 
   //
-  // Compute data for the timeline
+  // Computed values
   //
+  const epochsToDisplay = currentEpoch + 5;
+  const layersToDisplay = epochsToDisplay * (netInfo?.layersPerEpoch ?? 1);
+
+  const prevEpochsToDisplay = usePrevious(epochsToDisplay);
+  const prevLayersToDisplay = usePrevious(layersToDisplay);
+
+  const epochsDelta = epochsToDisplay - prevEpochsToDisplay;
+  const layersDelta = layersToDisplay - prevLayersToDisplay;
+
+  // Update epochs
   useEffect(() => {
     if (!netInfo) return;
-    const epochsToDisplay = currentEpoch + 5;
-    const layersToDisplay = epochsToDisplay * netInfo.layersPerEpoch;
-    const smesherEventsById = smesherStates
-      ? Object.entries(smesherStates)
-      : [];
-
-    // Create epochs
-    const epochs = new Array(epochsToDisplay).fill(null).map(
-      (_, index): TimelineItem<EpochDetails> => ({
-        content: `Epoch ${index}`,
-        id: `epoch_${index}`,
-        group: 'epochs',
-        start:
-          getEpochStartTime(
-            netInfo.layerDuration,
-            netInfo.layersPerEpoch,
-            index
-          ) + netInfo.genesisTime,
-        end:
-          getEpochEndTime(
-            netInfo.layerDuration,
-            netInfo.layersPerEpoch,
-            index
-          ) + netInfo.genesisTime,
-        // eslint-disable-next-line max-len
-        // TODO: Color epochs by it's status: general / failed / eligible
-        className: 'epoch',
-        data: {
-          title: `Epoch ${index}`,
-          type: TimelineItemType.Epoch,
-          details: {
-            identities: {},
+    const epochs = new Array(epochsDelta)
+      .fill(null)
+      .map((_, idx): TimelineItem<EpochDetails> => {
+        const index = idx + prevEpochsToDisplay;
+        return {
+          content: `Epoch ${index}`,
+          id: `epoch_${index}`,
+          group: 'epochs',
+          start:
+            getEpochStartTime(
+              netInfo.layerDuration,
+              netInfo.layersPerEpoch,
+              index
+            ) + netInfo.genesisTime,
+          end:
+            getEpochEndTime(
+              netInfo.layerDuration,
+              netInfo.layersPerEpoch,
+              index
+            ) + netInfo.genesisTime,
+          className: 'epoch',
+          data: {
+            title: `Epoch ${index}`,
+            type: TimelineItemType.Epoch,
+            details: {
+              identities: {},
+            },
           },
-        },
-      })
-    );
+        };
+      });
     updateData(epochs);
+  }, [epochsDelta, netInfo, prevEpochsToDisplay]);
 
-    // Create layers
-    const layers = new Array(layersToDisplay).fill(null).map(
-      (_, index): TimelineItem<LayerDetails> => ({
-        content: `${index}`,
-        id: `layer_${index}`,
-        group: 'layers',
-        start:
-          getLayerStartTime(netInfo.layerDuration, index) + netInfo.genesisTime,
-        end:
-          getLayerEndTime(netInfo.layerDuration, index) + netInfo.genesisTime,
-        // TODO: Color layers with estimated or received rewards
-        className: 'layer',
-        data: {
-          title: `Layer ${index}`,
-          type: TimelineItemType.Layer,
-          details: {
-            identities: {},
+  // Update layers
+  useEffect(() => {
+    if (!netInfo) return;
+    const layers = new Array(layersDelta)
+      .fill(null)
+      .map((_, idx): TimelineItem<LayerDetails> => {
+        const index = idx + prevLayersToDisplay;
+        return {
+          content: `${index}`,
+          id: `layer_${index}`,
+          group: 'layers',
+          start:
+            getLayerStartTime(netInfo.layerDuration, index) +
+            netInfo.genesisTime,
+          end:
+            getLayerEndTime(netInfo.layerDuration, index) + netInfo.genesisTime,
+          className: 'layer',
+          data: {
+            title: `Layer ${index}`,
+            type: TimelineItemType.Layer,
+            details: {
+              identities: {},
+            },
           },
-        },
-      })
-    );
+        };
+      });
     updateData(layers);
+  }, [layersDelta, netInfo, prevLayersToDisplay]);
 
-    if (poetInfo) {
-      // Create PoET cycle gaps
-      const cycleGaps = new Array(epochsToDisplay)
-        .fill(null)
-        .map((_, index): TimelineItem<CycleGapDetails> => {
+  // Update PoET rounds and cycle gaps
+  useEffect(() => {
+    if (!netInfo || !poetInfo) return;
+    const data = new Array(epochsDelta)
+      .fill(null)
+      .flatMap((_, idx): TimelineItem<CycleGapDetails>[] => {
+        const index = idx + prevEpochsToDisplay;
+        // Create PoET cycle gap
+        const cycleGap = (() => {
           const start = getCycleGapStart(poetInfo.config, netInfo, index);
           const end = getCycleGapEnd(poetInfo.config, netInfo, index);
           return {
@@ -204,19 +228,15 @@ const useTimelineData = () => {
             subgroup: 'cycleGap',
             start,
             end,
-            className: 'cycle-gap', // TODO: color by status
+            className: 'cycle-gap',
             data: {
               title: `CycleGap ${index}`,
               type: TimelineItemType.CycleGap,
             },
           };
-        });
-      updateData(cycleGaps);
-
-      // Create PoET rounds
-      const rounds = new Array(epochsToDisplay)
-        .fill(null)
-        .map((_, index): TimelineItem<PoetRoundDetails> => {
+        })();
+        // Create PoET round
+        const round = (() => {
           const start = getPoetRoundStart(poetInfo.config, netInfo, index);
           const end = getPoetRoundEnd(poetInfo.config, netInfo, index);
           return {
@@ -226,7 +246,7 @@ const useTimelineData = () => {
             subgroup: 'round',
             start,
             end,
-            className: 'poet-round', // TODO: color by status
+            className: 'poet-round',
             data: {
               title: `PoET Round #${index}`,
               type: TimelineItemType.PoetRound,
@@ -235,197 +255,377 @@ const useTimelineData = () => {
               },
             },
           };
-        });
-      updateData(rounds);
+        })();
+        // Return both
+        return [cycleGap, round];
+      });
+    updateData(data);
+  }, [epochsDelta, netInfo, poetInfo, prevEpochsToDisplay]);
 
-      // Events
-      smesherEventsById.forEach(([id, { history }]) => {
-        const group = smesherEventsById.length > 1 ? `smesher_${id}` : 'events';
-        const smesherRewards = rewards ? rewards[id] ?? [] : [];
-        // Record<EpochNumber, Record<LayerNumber, >>
-        const eligibilities: Record<
-          number,
-          Record<number, 'eligible' | 'rewarded' | 'missed'>
-        > = {};
-
-        const updated = <TimelineItem[]>[];
-        history
-          .sort(
-            (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime()
+  // Update events
+  const smesherEventsById = useMemo(
+    () => smesherStates && Object.entries(smesherStates),
+    [smesherStates]
+  );
+  const smesherEventsAmountById = useMemo(
+    () =>
+      smesherEventsById
+        ? Object.fromEntries(
+            smesherEventsById.map(([idx, { history }]) => [idx, history.length])
           )
-          .forEach((item) => {
-            const details = SmesherEvents.pickSmesherEventDetails(item);
+        : {},
+    [smesherEventsById]
+  );
+  const prevSmesherEventsIdx = usePrevious(smesherEventsAmountById);
+  useEffect(() => {
+    if (!netInfo || !poetInfo || !smesherEventsById) return;
+    const hasManyIdentities = smesherEventsById.length > 1;
+    smesherEventsById.forEach(([id, { history }]) => {
+      const delta =
+        (smesherEventsAmountById[id] ?? 0) - (prevSmesherEventsIdx[id] ?? 0);
+      const group = hasManyIdentities ? `smesher_${id}` : 'events';
+      const smesherRewards = rewards ? rewards[id] ?? [] : [];
+      const eligibilities: Record<
+        number,
+        Record<number, 'eligible' | 'rewarded'>
+      > = {};
 
-            // Get layer, epoch, and round numbers
-            const atTime = new Date(item.time).getTime();
-            const atLayer = getLayerByTime(
-              netInfo.layerDuration,
-              netInfo.genesisTime,
-              atTime
+      const updated = <TimelineItem[]>[];
+
+      history.slice(-delta).forEach((item) => {
+        const details = SmesherEvents.pickSmesherEventDetails(item);
+
+        // Get layer, epoch, and round numbers
+        const atTime = new Date(item.time).getTime();
+        const atLayer = getLayerByTime(
+          netInfo.layerDuration,
+          netInfo.genesisTime,
+          atTime
+        );
+        const atEpoch = getEpochByLayer(netInfo.layersPerEpoch, atLayer);
+        const atRound = getPoetRoundByTime(poetInfo.config, netInfo, atTime);
+
+        const affectedRound = atRound + 1;
+        const affectedEpoch = affectedRound + 1;
+
+        // Update epochs and layers
+
+        if (item.state === SmesherEvents.EventName.ELIGIBLE) {
+          const d = details as SmesherEvents.EligibleEventDetails;
+          // Mark eligible / rewarded layers
+          d.layers.forEach((layer) => {
+            const eligibleLayer = getData(`layer_${layer.layer}`);
+            if (eligibleLayer) {
+              const rewarded = smesherRewards.find(
+                (r) => r.layerPaid === layer.layer
+              );
+              const missed = !rewarded && layerByTime > layer.layer;
+              eligibilities[atEpoch] = {
+                ...eligibilities[atEpoch],
+                [layer.layer]: rewarded ? 'rewarded' : 'eligible',
+              };
+              updated.push(
+                updateItem(eligibleLayer, {
+                  // eslint-disable-next-line no-nested-ternary
+                  className: rewarded
+                    ? 'layer rewarded'
+                    : missed
+                    ? 'layer failed'
+                    : 'layer eligible',
+                  identities: {
+                    // eslint-disable-next-line no-nested-ternary
+                    [id]: rewarded
+                      ? {
+                          state: IdentityState.SUCCESS,
+                          details: `Got reward for Layer ${
+                            layer.layer
+                          }: ${formatSmidge(
+                            // eslint-disable-next-line max-len
+                            rewarded.rewardForFees + rewarded.rewardForLayer
+                          )} to ${rewarded.coinbase} (weight ${layer.count})`,
+                        }
+                      : missed
+                      ? {
+                          state: IdentityState.FAILURE,
+                          // eslint-disable-next-line max-len
+                          details: `Missed publishing proposal at layer ${layer.layer}`,
+                        }
+                      : {
+                          state: IdentityState.ELIGIBLE,
+                          details: `Eligible in Layer ${layer.layer}`,
+                        },
+                  },
+                  content: layer.layer.toString(),
+                })
+              );
+            }
+          });
+
+          const eligibleLayersString = d.layers.map((l) => l.layer).join(', ');
+
+          setMessage(
+            id,
+            'success',
+            // eslint-disable-next-line max-len
+            `Eligible in Layers ${eligibleLayersString} in epoch ${atEpoch}`
+          );
+
+          // Mark eligible epoch
+          const epoch = getData(`epoch_${atEpoch}`);
+          if (epoch) {
+            updated.push(
+              updateItem(epoch, {
+                className: 'epoch eligible',
+                identities: {
+                  [id]: {
+                    state: IdentityState.ELIGIBLE,
+                    details: `Eligible in Layers ${d.layers
+                      .map((l) => l.layer)
+                      .join(', ')}`,
+                  },
+                },
+              })
             );
-            const atEpoch = getEpochByLayer(netInfo.layersPerEpoch, atLayer);
-            const atRound = getPoetRoundByTime(
-              poetInfo.config,
-              netInfo,
-              atTime
+          }
+        }
+
+        if (item.state === SmesherEvents.EventName.PROPOSAL_PUBLISHED) {
+          const data = details as SmesherEvents.ProposalPublishedEventDetails;
+          const layer = getData(`layer_${data.layer}`);
+          if (layer) {
+            setMessage(
+              id,
+              'success',
+              // eslint-disable-next-line max-len
+              `Proposal published for Layer ${data.layer} in epoch ${atEpoch}`
             );
+            updated.push(
+              updateItem(layer, {
+                className: 'layer rewarded',
+                identities: {
+                  [id]: {
+                    state: IdentityState.SUCCESS,
+                    details: 'Proposal published',
+                  },
+                },
+              })
+            );
+          }
 
-            const affectedRound = atRound + 1;
-            const affectedEpoch = affectedRound + 1;
+          // Update epoch status
+          const epochItem = getData(`epoch_${atEpoch}`);
+          if (epochItem) {
+            const epochHasAllRewards = Object.values(
+              eligibilities[atEpoch] ?? {}
+            ).every((x) => x === 'rewarded');
+            const epochPassed = currentEpoch > atEpoch;
+            // eslint-disable-next-line no-nested-ternary
+            const [className, idStatus] = epochHasAllRewards
+              ? [
+                  'epoch rewarded',
+                  {
+                    // Rewarded
+                    state: IdentityState.SUCCESS,
+                    details: `Got all rewards for epoch ${atEpoch}`,
+                  },
+                ]
+              : epochPassed
+              ? [
+                  'epoch failed',
+                  {
+                    // Missed some rewards in epoch
+                    state: IdentityState.FAILURE,
+                    details: `Missed rewards for layers ${Object.entries(
+                      eligibilities[atEpoch] ?? {}
+                    )
+                      .filter(([, status]) => status !== 'rewarded')
+                      .map(([layerNum]) => layerNum)
+                      .join(', ')}`,
+                  },
+                ]
+              : [
+                  'epoch pending',
+                  {
+                    // Waiting for rewards...
+                    state: IdentityState.PENDING,
+                    details: `Getting rewards...`,
+                  },
+                ];
 
-            // Update epochs and layers
+            if (className && idStatus) {
+              updated.push(
+                updateItem(epochItem, {
+                  className,
+                  identities: {
+                    [id]: idStatus,
+                  },
+                })
+              );
+            }
+          }
+        }
 
-            if (item.state === SmesherEvents.EventName.ELIGIBLE) {
-              const d = details as SmesherEvents.EligibleEventDetails;
-              // Mark eligible / rewarded layers
-              d.layers.forEach((layer) => {
-                const eligibleLayer = getData(`layer_${layer.layer}`);
-                if (eligibleLayer) {
-                  const rewarded = smesherRewards.find(
-                    (r) => r.layerPaid === layer.layer
-                  );
-                  const missed = !rewarded && layerByTime > layer.layer;
-                  eligibilities[atEpoch] = {
-                    ...eligibilities[atEpoch],
-                    [layer.layer]: rewarded ? 'rewarded' : 'eligible',
-                  };
-                  updated.push(
-                    updateItem(eligibleLayer, {
-                      // eslint-disable-next-line no-nested-ternary
-                      className: rewarded
-                        ? 'layer success'
-                        : missed
-                        ? 'layer failed'
-                        : 'layer eligible',
-                      identities: {
-                        // eslint-disable-next-line no-nested-ternary
-                        [id]: rewarded
-                          ? {
-                              state: IdentityState.SUCCESS,
-                              details: `Got reward for Layer ${
-                                layer.layer
-                              }: ${formatSmidge(
-                                // eslint-disable-next-line max-len
-                                rewarded.rewardForFees + rewarded.rewardForLayer
-                              )} to ${rewarded.coinbase} (weight ${
-                                layer.count
-                              })`,
-                            }
-                          : missed
-                          ? {
-                              state: IdentityState.FAILURE,
-                              // eslint-disable-next-line max-len
-                              details: `Missed publishing proposal at layer ${layer.layer}`,
-                            }
-                          : {
-                              state: IdentityState.ELIGIBLE,
-                              details: `Eligible in Layer ${layer.layer}`,
-                            },
-                      },
-                      content: layer.layer.toString(),
-                    })
-                  );
-                }
-              });
+        if (
+          item.state === SmesherEvents.EventName.PROPOSAL_BUILD_FAILED ||
+          item.state === SmesherEvents.EventName.PROPOSAL_PUBLISH_FAILED
+        ) {
+          const epoch = getData(`epoch_${atEpoch}`);
+          if (epoch) {
+            updated.push(
+              updateItem(epoch, {
+                className: 'epoch failed',
+                identities: {
+                  [id]: {
+                    state: IdentityState.FAILURE,
+                    details: (
+                      details as
+                        | SmesherEvents.ProposalPublishFailedEventDetails
+                        | SmesherEvents.ProposalBuildFailedEventDetails
+                    ).message,
+                  },
+                },
+              })
+            );
+          }
 
-              const eligibleLayersString = d.layers
-                .map((l) => l.layer)
-                .join(', ');
+          const layer = getData(`layer_${atLayer}`);
+          if (layer) {
+            updated.push(
+              updateItem(layer, {
+                className: 'layer failed',
+                identities: {
+                  [id]: {
+                    state: IdentityState.FAILURE,
+                    details: `${
+                      item.state ===
+                      SmesherEvents.EventName.PROPOSAL_BUILD_FAILED
+                        ? 'Proposal build'
+                        : 'Proposal publish'
+                    } failed: ${
+                      (
+                        details as
+                          | SmesherEvents.ProposalPublishFailedEventDetails
+                          | SmesherEvents.ProposalBuildFailedEventDetails
+                      ).message
+                    }`,
+                  },
+                },
+              })
+            );
+          }
+        }
 
+        if (item.state === SmesherEvents.EventName.GENERATING_POST_PROOF) {
+          setMessage(id, 'success', 'Generating PoST proof...');
+        }
+
+        if (item.state === SmesherEvents.EventName.ATX_BROADCASTED) {
+          const epoch = getData(`epoch_${affectedEpoch}`);
+          if (epoch) {
+            const isOutdated = currentEpoch > affectedEpoch;
+            if (isOutdated) {
+              setMessage(
+                id,
+                'failed',
+                // eslint-disable-next-line max-len
+                `Did not published any proposal in ${affectedEpoch}`
+              );
+              updated.push(
+                updateItem(epoch, {
+                  className: 'epoch failed',
+                  identities: {
+                    [id]: {
+                      state: IdentityState.FAILURE,
+                      details: 'Missed publishing proposals',
+                    },
+                  },
+                })
+              );
+            } else {
               setMessage(
                 id,
                 'success',
                 // eslint-disable-next-line max-len
-                `Eligible in Layers ${eligibleLayersString} in epoch ${atEpoch}`
+                `ATX is broadcasted in epoch ${affectedEpoch}`
               );
-
-              // Mark eligible epoch
-              const epoch = getData(`epoch_${atEpoch}`);
-              if (epoch) {
-                updated.push(
-                  updateItem(epoch, {
-                    className: 'epoch eligible',
-                    identities: {
-                      [id]: {
-                        state: IdentityState.ELIGIBLE,
-                        details: `Eligible in Layers ${d.layers
-                          .map((l) => l.layer)
-                          .join(', ')}`,
-                      },
+              updated.push(
+                updateItem(epoch, {
+                  className: 'epoch eligible',
+                  identities: {
+                    [id]: {
+                      state: IdentityState.ELIGIBLE,
+                      details: 'ATX is broadcasted. Waiting for rewards...',
                     },
-                  })
-                );
-              }
+                  },
+                })
+              );
             }
+          }
+        }
 
-            if (item.state === SmesherEvents.EventName.PROPOSAL_PUBLISHED) {
-              const data =
-                details as SmesherEvents.ProposalPublishedEventDetails;
-              const layer = getData(`layer_${data.layer}`);
-              if (layer) {
-                setMessage(
-                  id,
-                  'success',
-                  // eslint-disable-next-line max-len
-                  `Proposal published for Layer ${data.layer} in epoch ${atEpoch}`
-                );
-                updated.push(
-                  updateItem(layer, {
-                    className: 'layer success',
-                    identities: {
-                      [id]: {
-                        state: IdentityState.SUCCESS,
-                        details: 'Proposal published',
-                      },
+        if (item.state === SmesherEvents.EventName.POET_PROOF_RECEIVED) {
+          const round = getData(`poet_round_${atRound}`);
+          if (round) {
+            setMessage(
+              id,
+              'success',
+              // eslint-disable-next-line max-len
+              `PoET proof received in round ${atRound}`
+            );
+            updated.push(
+              updateItem(round, {
+                className: 'poet-round success',
+                identities: {
+                  [id]: {
+                    state: IdentityState.SUCCESS,
+                    details: 'PoET proof received',
+                  },
+                },
+              })
+            );
+          }
+          const epoch = getData(`epoch_${affectedEpoch}`);
+          if (epoch) {
+            updated.push(
+              updateItem(epoch, {
+                className: 'epoch pending',
+                identities: {
+                  [id]: {
+                    state: IdentityState.PENDING,
+                    details:
+                      // eslint-disable-next-line max-len
+                      'PoET proof received, going to publish Activation Transaction',
+                  },
+                },
+              })
+            );
+          }
+        }
+        if (item.state === SmesherEvents.EventName.POET_REGISTERED) {
+          const round = getData(
+            `poet_round_${affectedRound}`
+          ) as TimelineItem<PoetRoundDetails>;
+          if (round) {
+            if (currentPoetRound > affectedRound) {
+              setMessage(
+                id,
+                'failed',
+                // eslint-disable-next-line max-len
+                `Did not received PoET proof for round ${affectedRound} in time. Will not have rewards in epoch ${affectedEpoch}`
+              );
+              updated.push(
+                updateItem(round, {
+                  className: 'poet-round failed',
+                  identities: {
+                    [id]: {
+                      state: IdentityState.FAILURE,
+                      // eslint-disable-next-line max-len
+                      details: `Did not received PoET proof for round ${affectedRound} in time`,
                     },
-                  })
-                );
-
-                // Update epoch status
-                const epoch = getData(`epoch_${atEpoch}`);
-                if (epoch) {
-                  updated.push(
-                    updateItem(epoch, {
-                      className: 'epoch pending',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.PENDING,
-                          details: 'Getting rewards...',
-                        },
-                      },
-                    })
-                  );
-                }
-              }
-
-              if (
-                Object.values(eligibilities[atEpoch] ?? {}).every(
-                  (x) => x === 'rewarded'
-                )
-              ) {
-                const epochItem = getData(`epoch_${atEpoch}`);
-                if (epochItem) {
-                  updated.push(
-                    updateItem(epochItem, {
-                      className: 'epoch rewarded',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.SUCCESS,
-                          // eslint-disable-next-line max-len
-                          details: `Got all rewards for epoch ${atEpoch}`,
-                        },
-                      },
-                    })
-                  );
-                }
-              }
-            }
-
-            if (
-              item.state === SmesherEvents.EventName.PROPOSAL_BUILD_FAILED ||
-              item.state === SmesherEvents.EventName.PROPOSAL_PUBLISH_FAILED
-            ) {
-              const epoch = getData(`epoch_${atEpoch}`);
+                  },
+                })
+              );
+              const epoch = getData(`epoch_${affectedEpoch + 1}`);
               if (epoch) {
                 updated.push(
                   updateItem(epoch, {
@@ -433,332 +633,164 @@ const useTimelineData = () => {
                     identities: {
                       [id]: {
                         state: IdentityState.FAILURE,
-                        details: (
-                          details as
-                            | SmesherEvents.ProposalPublishFailedEventDetails
-                            | SmesherEvents.ProposalBuildFailedEventDetails
-                        ).message,
+                        // eslint-disable-next-line max-len
+                        details: `Did not received PoET proof for round ${affectedRound} in time`,
                       },
                     },
                   })
                 );
               }
-
-              const layer = getData(`layer_${atLayer}`);
-              if (layer) {
-                updated.push(
-                  updateItem(layer, {
-                    className: 'layer failed',
-                    identities: {
-                      [id]: {
-                        state: IdentityState.FAILURE,
-                        details: `${
-                          item.state ===
-                          SmesherEvents.EventName.PROPOSAL_BUILD_FAILED
-                            ? 'Proposal build'
-                            : 'Proposal publish'
-                        } failed: ${
-                          (
-                            details as
-                              | SmesherEvents.ProposalPublishFailedEventDetails
-                              | SmesherEvents.ProposalBuildFailedEventDetails
-                          ).message
-                        }`,
-                      },
+            } else {
+              setMessage(
+                id,
+                'success',
+                // eslint-disable-next-line max-len
+                `Registered in PoET round ${affectedRound}`
+              );
+              updated.push(
+                updateItem(round, {
+                  className: 'poet-round eligible',
+                  identities: {
+                    [id]: {
+                      state: IdentityState.ELIGIBLE,
+                      details: 'Registered in PoET',
                     },
-                  })
-                );
-              }
-            }
-
-            if (item.state === SmesherEvents.EventName.GENERATING_POST_PROOF) {
-              setMessage(id, 'success', 'Generating PoST proof...');
-            }
-
-            if (item.state === SmesherEvents.EventName.ATX_BROADCASTED) {
-              const epoch = getData(`epoch_${affectedEpoch}`);
-              if (epoch) {
-                const epochEndTime =
-                  getEpochEndTime(
-                    netInfo.layerDuration,
-                    netInfo.layersPerEpoch,
-                    affectedEpoch
-                  ) + netInfo.genesisTime;
-                const isOutdated = currentTime > epochEndTime;
-
-                if (isOutdated) {
-                  setMessage(
-                    id,
-                    'failed',
-                    // eslint-disable-next-line max-len
-                    `Did not published any proposal in ${affectedEpoch}`
-                  );
-                  updated.push(
-                    updateItem(epoch, {
-                      className: 'epoch failed',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.FAILURE,
-                          details: 'Missed publishing proposals',
-                        },
-                      },
-                    })
-                  );
-                } else {
-                  setMessage(
-                    id,
-                    'success',
-                    // eslint-disable-next-line max-len
-                    `ATX is broadcasted in epoch ${affectedEpoch}`
-                  );
-                  updated.push(
-                    updateItem(epoch, {
-                      className: 'epoch eligible',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.ELIGIBLE,
-                          details: 'ATX is broadcasted. Waiting for rewards...',
-                        },
-                      },
-                    })
-                  );
-                }
-              }
-            }
-
-            if (item.state === SmesherEvents.EventName.POET_PROOF_RECEIVED) {
-              const round = getData(`poet_round_${atRound}`);
-              if (round) {
-                setMessage(
-                  id,
-                  'success',
-                  // eslint-disable-next-line max-len
-                  `PoET proof received in round ${atRound}`
-                );
-                updated.push(
-                  updateItem(round, {
-                    className: 'poet-round success',
-                    identities: {
-                      [id]: {
-                        state: IdentityState.SUCCESS,
-                        details: 'PoET proof received',
-                      },
-                    },
-                  })
-                );
-              }
-              const epoch = getData(`epoch_${affectedEpoch}`);
+                  },
+                })
+              );
+              const epoch = getData(`epoch_${affectedEpoch + 1}`);
               if (epoch) {
                 updated.push(
                   updateItem(epoch, {
-                    className: 'epoch pending',
+                    className: 'epoch eligible',
                     identities: {
                       [id]: {
-                        state: IdentityState.PENDING,
+                        state: IdentityState.ELIGIBLE,
+                        // eslint-disable-next-line max-len
                         details:
-                          // eslint-disable-next-line max-len
-                          'PoET proof received, going to publish Activation Transaction',
+                          'Registered in PoET. Waiting for PoET proof...',
                       },
                     },
                   })
                 );
               }
             }
-            if (item.state === SmesherEvents.EventName.POET_REGISTERED) {
-              const round = getData(
-                `poet_round_${affectedRound}`
-              ) as TimelineItem<PoetRoundDetails>;
-              if (round) {
-                if (
-                  currentTime >
-                  getPoetRoundEnd(poetInfo.config, netInfo, affectedRound) +
-                    netInfo.genesisTime
-                ) {
-                  setMessage(
-                    id,
-                    'failed',
-                    // eslint-disable-next-line max-len
-                    `Did not received PoET proof for round ${affectedRound} in time. Will not have rewards in epoch ${affectedEpoch}`
-                  );
-                  updated.push(
-                    updateItem(round, {
-                      className: 'poet-round failed',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.FAILURE,
-                          // eslint-disable-next-line max-len
-                          details: `Did not received PoET proof for round ${affectedRound} in time`,
-                        },
-                      },
-                    })
-                  );
-                  const epoch = getData(`epoch_${affectedEpoch + 1}`);
-                  if (epoch) {
-                    updated.push(
-                      updateItem(epoch, {
-                        className: 'epoch failed',
-                        identities: {
-                          [id]: {
-                            state: IdentityState.FAILURE,
-                            // eslint-disable-next-line max-len
-                            details: `Did not received PoET proof for round ${affectedRound} in time`,
-                          },
-                        },
-                      })
-                    );
-                  }
-                } else {
-                  setMessage(
-                    id,
-                    'success',
-                    // eslint-disable-next-line max-len
-                    `Registered in PoET round ${affectedRound}`
-                  );
-                  updated.push(
-                    updateItem(round, {
-                      className: 'poet-round eligible',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.ELIGIBLE,
-                          details: 'Registered in PoET',
-                        },
-                      },
-                    })
-                  );
-                  const epoch = getData(`epoch_${affectedEpoch + 1}`);
-                  if (epoch) {
-                    updated.push(
-                      updateItem(epoch, {
-                        className: 'epoch eligible',
-                        identities: {
-                          [id]: {
-                            state: IdentityState.ELIGIBLE,
-                            // eslint-disable-next-line max-len
-                            details:
-                              'Registered in PoET. Waiting for PoET proof...',
-                          },
-                        },
-                      })
-                    );
-                  }
-                }
-              }
-            }
+          }
+        }
 
-            if (
-              item.state ===
-              SmesherEvents.EventName.WAITING_FOR_POET_REGISTRATION_WINDOW
-            ) {
-              // Mark next PoET round...
-              const nextRound = getData(
-                `poet_round_${affectedRound}`
-              ) as TimelineItem<PoetRoundDetails>;
-              if (nextRound) {
-                // TODO: Mark as failed or success
-                const roundNow = getPoetRoundByTime(
-                  poetInfo.config,
-                  netInfo,
-                  Date.now()
-                );
-                // Mark as failed due to missing it
-                if (affectedRound < roundNow) {
-                  setMessage(
-                    id,
-                    'failed',
-                    `Missed PoET registration window in round ${affectedRound}`
-                  );
-                  updated.push(
-                    updateItem(nextRound, {
-                      className: 'poet-round failed',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.FAILURE,
-                          details: 'Missed PoET registration window',
-                        },
-                      },
-                    })
-                  );
-                } else {
-                  // Mark as pending
-                  setMessage(
-                    id,
-                    'pending',
-                    // eslint-disable-next-line max-len
-                    `Waiting for PoET registration window in round ${affectedRound}`
-                  );
-                  updated.push(
-                    updateItem(nextRound, {
-                      className: 'poet-round pending',
-                      identities: {
-                        [id]: {
-                          state: IdentityState.PENDING,
-                          details: 'Waiting for PoET registration window',
-                        },
-                      },
-                    })
-                  );
-                }
-              }
-            }
-
-            // Add / update data
-            updated.push({
-              content: getSmesherEventTitle(item.state),
-              id: `smeshing_${id}_${item.state}_${item.time}`,
-              group,
-              subgroup: item.state,
-              start: new Date(item.time).getTime(),
-              type: 'point',
-              className:
-                item.state === SmesherEvents.EventName.RETRYING ||
-                item.state === SmesherEvents.EventName.PROPOSAL_BUILD_FAILED ||
-                item.state === SmesherEvents.EventName.PROPOSAL_PUBLISH_FAILED
-                  ? 'smesher-event failure'
-                  : 'smesher-event',
-              data: {
-                title: getSmesherEventTitle(item.state),
-                type: TimelineItemType.Event,
-                details,
-              },
-            });
-          });
-
-        if (rewards && rewards[id]) {
-          rewards[id]?.forEach((reward) => {
-            const layer = getData(`layer_${reward.layerPaid}`);
-            if (layer) {
+        if (
+          item.state ===
+          SmesherEvents.EventName.WAITING_FOR_POET_REGISTRATION_WINDOW
+        ) {
+          // Mark next PoET round...
+          const nextRound = getData(
+            `poet_round_${affectedRound}`
+          ) as TimelineItem<PoetRoundDetails>;
+          if (nextRound) {
+            // TODO: Mark as failed or success
+            const roundNow = getPoetRoundByTime(
+              poetInfo.config,
+              netInfo,
+              Date.now()
+            );
+            // Mark as failed due to missing it
+            if (affectedRound < roundNow) {
+              setMessage(
+                id,
+                'failed',
+                `Missed PoET registration window in round ${affectedRound}`
+              );
               updated.push(
-                updateItem(layer, {
-                  className: 'layer rewarded',
+                updateItem(nextRound, {
+                  className: 'poet-round failed',
                   identities: {
                     [id]: {
-                      state: IdentityState.SUCCESS,
-                      details: `Got reward for Layer ${
-                        reward.layerPaid
-                      }: ${formatSmidge(
-                        reward.rewardForFees + reward.rewardForLayer
-                      )} to ${reward.coinbase}`,
+                      state: IdentityState.FAILURE,
+                      details: 'Missed PoET registration window',
+                    },
+                  },
+                })
+              );
+            } else {
+              // Mark as pending
+              setMessage(
+                id,
+                'pending',
+                // eslint-disable-next-line max-len
+                `Waiting for PoET registration window in round ${affectedRound}`
+              );
+              updated.push(
+                updateItem(nextRound, {
+                  className: 'poet-round pending',
+                  identities: {
+                    [id]: {
+                      state: IdentityState.PENDING,
+                      details: 'Waiting for PoET registration window',
                     },
                   },
                 })
               );
             }
-          });
+          }
         }
 
-        updateData(updated);
+        // Add / update data
+        updated.push({
+          content: getSmesherEventTitle(item.state),
+          id: `smeshing_${id}_${item.state}_${item.time}`,
+          group,
+          subgroup: item.state,
+          start: new Date(item.time).getTime(),
+          type: 'point',
+          className:
+            item.state === SmesherEvents.EventName.RETRYING ||
+            item.state === SmesherEvents.EventName.PROPOSAL_BUILD_FAILED ||
+            item.state === SmesherEvents.EventName.PROPOSAL_PUBLISH_FAILED
+              ? 'smesher-event failure'
+              : 'smesher-event',
+          data: {
+            title: getSmesherEventTitle(item.state),
+            type: TimelineItemType.Event,
+            details,
+          },
+        });
       });
-      // End of updating data
-    }
+
+      if (rewards && rewards[id]) {
+        rewards[id]?.forEach((reward) => {
+          const layer = getData(`layer_${reward.layerPaid}`);
+          if (layer) {
+            updated.push(
+              updateItem(layer, {
+                className: 'layer rewarded',
+                identities: {
+                  [id]: {
+                    state: IdentityState.SUCCESS,
+                    details: `Got reward for Layer ${
+                      reward.layerPaid
+                    }: ${formatSmidge(
+                      reward.rewardForFees + reward.rewardForLayer
+                    )} to ${reward.coinbase}`,
+                  },
+                },
+              })
+            );
+          }
+        });
+      }
+
+      updateData(updated);
+    });
   }, [
     currentEpoch,
-    currentTime,
-    epochDuration,
+    currentPoetRound,
     layerByTime,
     netInfo,
     poetInfo,
+    prevSmesherEventsIdx,
     rewards,
-    smesherStates,
+    smesherEventsAmountById,
+    smesherEventsById,
   ]);
 
   const nestedEventGroups = useMemo(() => {

--- a/src/hooks/useTimelineData.ts
+++ b/src/hooks/useTimelineData.ts
@@ -328,12 +328,34 @@ const useTimelineData = () => {
                 }
               });
 
+              const eligibleLayersString = d.layers
+                .map((l) => l.layer)
+                .join(', ');
+
               setMessage(
                 id,
                 'success',
                 // eslint-disable-next-line max-len
-                `Eligible in Layers ${d.layers.map((l) => l.layer).join(', ')}`
+                `Eligible in Layers ${eligibleLayersString} in epoch ${atEpoch}`
               );
+
+              // Mark eligible epoch
+              const epoch = getData(`epoch_${atEpoch}`);
+              if (epoch) {
+                updated.push(
+                  updateItem(epoch, {
+                    className: 'epoch eligible',
+                    identities: {
+                      [id]: {
+                        state: IdentityState.ELIGIBLE,
+                        details: `Eligible in Layers ${d.layers
+                          .map((l) => l.layer)
+                          .join(', ')}`,
+                      },
+                    },
+                  })
+                );
+              }
             }
 
             if (item.state === SmesherEvents.EventName.PROPOSAL_PUBLISHED) {
@@ -358,6 +380,22 @@ const useTimelineData = () => {
                     },
                   })
                 );
+
+                // Update epoch status
+                const epoch = getData(`epoch_${atEpoch}`);
+                if (epoch) {
+                  updated.push(
+                    updateItem(epoch, {
+                      className: 'epoch pending',
+                      identities: {
+                        [id]: {
+                          state: IdentityState.PENDING,
+                          details: 'Getting rewards...',
+                        },
+                      },
+                    })
+                  );
+                }
               }
 
               if (
@@ -554,7 +592,7 @@ const useTimelineData = () => {
                       },
                     })
                   );
-                  const epoch = getData(`epoch_${affectedEpoch}`);
+                  const epoch = getData(`epoch_${affectedEpoch + 1}`);
                   if (epoch) {
                     updated.push(
                       updateItem(epoch, {
@@ -587,6 +625,22 @@ const useTimelineData = () => {
                       },
                     })
                   );
+                  const epoch = getData(`epoch_${affectedEpoch + 1}`);
+                  if (epoch) {
+                    updated.push(
+                      updateItem(epoch, {
+                        className: 'epoch eligible',
+                        identities: {
+                          [id]: {
+                            state: IdentityState.ELIGIBLE,
+                            // eslint-disable-next-line max-len
+                            details:
+                              'Registered in PoET. Waiting for PoET proof...',
+                          },
+                        },
+                      })
+                    );
+                  }
                 }
               }
             }

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -27,6 +27,7 @@ import StatusBulb, { getStatusByStore } from '../components/basic/StatusBulb';
 import TableContents from '../components/basic/TableContents';
 import SmeshingTimeline from '../components/timeline/SmeshingTimeline';
 import useTimelineData from '../hooks/useTimelineData';
+import useActivations from '../store/useActivations';
 import useEligibilities from '../store/useEligibilities';
 import useNetworkInfo from '../store/useNetworkInfo';
 import useNodeStatus from '../store/useNodeStatus';
@@ -63,6 +64,7 @@ function DashboardScreen(): JSX.Element {
     useSmesherConnection();
   const NetInfo = useNetworkInfo();
   const Node = useNodeStatus();
+  const Activations = useActivations();
   const PoET = usePoETInfo();
   const SmesherStates = useSmesherStates();
   const Eligibilities = useEligibilities();
@@ -261,6 +263,7 @@ function DashboardScreen(): JSX.Element {
                         ['Applied layer', Node.data.appliedLayer],
                         ['Latest layer', Node.data.latestLayer],
                         ['Connected peers', Node.data.connectedPeers],
+                        ['Activations', Activations.data?.count ?? '???'],
                       ]}
                     />
                   </Table>

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -428,9 +428,14 @@ function DashboardScreen(): JSX.Element {
                                           size="sm"
                                           mr={0.5}
                                           mb={0.5}
+                                          // eslint-disable-next-line max-len
+                                          // eslint-disable-next-line no-nested-ternary
                                           {...(proposals.has(el.layer)
                                             ? { colorScheme: 'green' }
-                                            : {})}
+                                            : (Node?.data?.currentLayer ?? 0) >=
+                                              el.layer
+                                            ? { colorScheme: 'red' }
+                                            : { colorScheme: 'yellow' })}
                                         >
                                           {el.layer}
                                         </Tag>

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -340,7 +340,8 @@ function DashboardScreen(): JSX.Element {
                           >
                             {index + 1}
                           </Box>
-                          {data.smesherMessages[id]?.message ?? ''}
+                          {data.smesherMessages[id]?.message ??
+                            'Waiting for the smesher events...'}
                         </Text>
 
                         <Text mb={2} color="gray.300">

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -41,6 +41,8 @@ import { SECOND } from '../utils/constants';
 import { formatTimestamp } from '../utils/datetime';
 import { sortHexString } from '../utils/hexString';
 import { formatSmidge } from '../utils/smh';
+import useWhyDidUpdate from '../hooks/useWhyDidUpdate';
+import { N } from '@mobily/ts-belt';
 
 function OptionalError({
   store,
@@ -77,6 +79,15 @@ function DashboardScreen(): JSX.Element {
     setConnection('');
     navigate('/');
   };
+
+  useWhyDidUpdate('DashboardScreen', {
+    NetInfo,
+    Node,
+    SmesherStates,
+    Eligibilities,
+    Proposals,
+    Rewards,
+  });
 
   const nodeStatusStore = getStatusByStore(Node);
   const nodeStatusBulb =

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -268,24 +268,29 @@ function DashboardScreen(): JSX.Element {
                               0x{id}
                             </Text>
 
-                            <Text fontSize="xs" color="gray.500">
-                              Eligible for{' '}
-                              {/* eslint-disable-next-line max-len */}
-                              <strong>
-                                {eligibilityStats.layers} layers
-                              </strong>{' '}
-                              <span>in {eligibilityStats.epochs} epochs</span>
-                            </Text>
-                            <Text fontSize="xs" color="gray.500">
-                              Published
-                              <strong>{proposalStats} proposals</strong>
-                            </Text>
-                            <Text fontSize="xs" color="gray.500">
-                              {/* eslint-disable-next-line max-len */}
-                              Earned <strong>
-                                {rewardStats.income}
-                              </strong> in {rewardStats.rewards} rewards
-                            </Text>
+                            <Flex
+                              flexDir={{ base: 'column', lg: 'row' }}
+                              gap={{ base: 1, lg: 10 }}
+                            >
+                              <Text fontSize="xs" color="gray.500">
+                                Eligible for{' '}
+                                {/* eslint-disable-next-line max-len */}
+                                <strong>
+                                  {eligibilityStats.layers} layers
+                                </strong>{' '}
+                                <span>in {eligibilityStats.epochs} epochs</span>
+                              </Text>
+                              <Text fontSize="xs" color="gray.500">
+                                Published
+                                <strong>{proposalStats} proposals</strong>
+                              </Text>
+                              <Text fontSize="xs" color="gray.500">
+                                {/* eslint-disable-next-line max-len */}
+                                Earned <strong>
+                                  {rewardStats.income}
+                                </strong> in {rewardStats.rewards} rewards
+                              </Text>
+                            </Flex>
                           </Box>
                           <AccordionIcon />
                         </AccordionButton>

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -432,7 +432,7 @@ function DashboardScreen(): JSX.Element {
                                           // eslint-disable-next-line no-nested-ternary
                                           {...(proposals.has(el.layer)
                                             ? { colorScheme: 'green' }
-                                            : (Node?.data?.currentLayer ?? 0) >=
+                                            : (Node?.data?.currentLayer ?? 0) >
                                               el.layer
                                             ? { colorScheme: 'red' }
                                             : { colorScheme: 'yellow' })}

--- a/src/store/useActivations.ts
+++ b/src/store/useActivations.ts
@@ -1,0 +1,51 @@
+import { useEffect, useMemo } from 'react';
+import { singletonHook } from 'react-singleton-hook';
+
+import { fetchActivationsCount } from '../api/requests/activations';
+import { MINUTE } from '../utils/constants';
+
+import createDynamicStore, {
+  createViewOnlyDynamicStore,
+  getDynamicStoreDefaults,
+} from './utils/createDynamicStore';
+import useNodeStatus from './useNodeStatus';
+import useSmesherConnection from './useSmesherConnection';
+
+const useActivationsStore = createDynamicStore<{
+  count: number;
+}>();
+
+const useActivations = () => {
+  const store = useActivationsStore();
+  const Node = useNodeStatus();
+  const { getConnection } = useSmesherConnection();
+  const rpc = getConnection();
+  const { setData } = store;
+  const { isSynced } = Node.data || {};
+  useEffect(() => {
+    let ival: ReturnType<typeof setInterval> | null = null;
+
+    if (rpc) {
+      const fetcher = () =>
+        fetchActivationsCount(rpc).then((res) => {
+          setData({ count: res });
+        });
+
+      fetcher();
+      if (!isSynced) {
+        if (ival) {
+          clearInterval(ival);
+        }
+        ival = setInterval(fetcher, MINUTE);
+      }
+    }
+    return () => {
+      if (ival) {
+        clearInterval(ival);
+      }
+    };
+  }, [isSynced, rpc, setData]);
+  return useMemo(() => createViewOnlyDynamicStore(store), [store]);
+};
+
+export default singletonHook(getDynamicStoreDefaults(), useActivations);

--- a/src/store/useRewards.ts
+++ b/src/store/useRewards.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { singletonHook } from 'react-singleton-hook';
 
 import { fetchRewardsBySmesherIds } from '../api/requests/rewards';
@@ -17,28 +17,11 @@ const useRewardsStore = createDynamicStore<RewardsState>();
 
 const useRewards = () => {
   const store = useRewardsStore();
-  const idsRef = useRef(new Set<HexString>());
   const ids = useSmesherIds();
-  const [identities, setIdentities] = useState(<HexString[]>[]);
-
-  useEffect(() => {
-    // Update idsRef list
-    if (!ids) return;
-    let changed = false;
-    ids.forEach((id) => {
-      if (!idsRef.current.has(id)) {
-        idsRef.current.add(id);
-        changed = true;
-      }
-    });
-    if (changed) {
-      setIdentities(Array.from(idsRef.current));
-    }
-  }, [ids]);
 
   const fetchRewards = useMemo(
-    () => fetchRewardsBySmesherIds(Array.from(identities)),
-    [identities]
+    () => fetchRewardsBySmesherIds(ids ?? []),
+    [ids]
   );
   useEveryLayerFetcher(store, fetchRewards);
   return useMemo(() => createViewOnlyDynamicStore(store), [store]);

--- a/src/store/useRewards.ts
+++ b/src/store/useRewards.ts
@@ -10,21 +10,20 @@ import createDynamicStore, {
   getDynamicStoreDefaults,
 } from './utils/createDynamicStore';
 import useEveryLayerFetcher from './utils/useEveryLayerFetcher';
-import useSmesherStates from './useSmesherStates';
+import { useSmesherIds } from './useSmesherStates';
 
 type RewardsState = Record<HexString, Reward[]>;
 const useRewardsStore = createDynamicStore<RewardsState>();
 
 const useRewards = () => {
   const store = useRewardsStore();
-  const { data } = useSmesherStates();
   const idsRef = useRef(new Set<HexString>());
+  const ids = useSmesherIds();
   const [identities, setIdentities] = useState(<HexString[]>[]);
 
   useEffect(() => {
     // Update idsRef list
-    if (!data) return;
-    const ids = Object.keys(data);
+    if (!ids) return;
     let changed = false;
     ids.forEach((id) => {
       if (!idsRef.current.has(id)) {
@@ -35,7 +34,7 @@ const useRewards = () => {
     if (changed) {
       setIdentities(Array.from(idsRef.current));
     }
-  }, [data]);
+  }, [ids]);
 
   const fetchRewards = useMemo(
     () => fetchRewardsBySmesherIds(Array.from(identities)),

--- a/src/store/useSmesherStates.ts
+++ b/src/store/useSmesherStates.ts
@@ -1,21 +1,63 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { singletonHook } from 'react-singleton-hook';
 
-import { fetchSmesherStates } from '../api/requests/smesherState';
+import {
+  fetchSmesherStatesWithCallback,
+  mergeSmesherStates,
+} from '../api/requests/smesherState';
 import { SmesherIdentities } from '../api/schemas/smesherStates';
+import { SECOND } from '../utils/constants';
 
 import createDynamicStore, {
   createViewOnlyDynamicStore,
   getDynamicStoreDefaults,
 } from './utils/createDynamicStore';
-import useEveryLayerFetcher from './utils/useEveryLayerFetcher';
+import useNetworkInfo from './useNetworkInfo';
+import useSmesherConnection from './useSmesherConnection';
 
 const useSmesherStateStore = createDynamicStore<SmesherIdentities>();
 
 const useSmesherStates = () => {
   const store = useSmesherStateStore();
-  useEveryLayerFetcher(store, fetchSmesherStates);
+  const { data: netInfo } = useNetworkInfo();
+  const { getConnection } = useSmesherConnection();
+  const rpc = getConnection();
+
+  const { setData } = store;
+
+  const fetcher = useMemo(() => {
+    console.log('fetcher called');
+    return fetchSmesherStatesWithCallback((newStates) =>
+      setData((prev) => {
+        console.time('merge');
+        const res = prev ? mergeSmesherStates(prev, newStates) : newStates;
+        console.timeEnd('merge');
+        return res;
+      })
+    );
+  }, [setData]);
+
+  useEffect(() => {
+    console.log('use effect!');
+    // let ival: ReturnType<typeof setInterval> | null = null;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    if (fetcher && rpc && netInfo?.layerDuration) {
+      // ival = setInterval(() => fetcher(rpc), netInfo.layerDuration * SECOND);
+      timeout = setTimeout(() => fetcher(rpc), 5 * SECOND);
+    }
+    console.log('...');
+    return () => {
+      // if (ival) clearInterval(ival);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [fetcher, netInfo, rpc]);
   return useMemo(() => createViewOnlyDynamicStore(store), [store]);
+};
+
+export const useSmesherIds = () => {
+  const { data } = useSmesherStates();
+  return useMemo(() => data && Object.keys(data), [data]);
 };
 
 export default singletonHook(getDynamicStoreDefaults(), useSmesherStates);

--- a/src/store/useSmesherStates.ts
+++ b/src/store/useSmesherStates.ts
@@ -1,35 +1,60 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { singletonHook } from 'react-singleton-hook';
 
-import {
-  fetchSmesherStatesWithCallback,
-  mergeSmesherStates,
-} from '../api/requests/smesherState';
-import { SmesherIdentities } from '../api/schemas/smesherStates';
+import { fetchSmesherStatesWithCallback } from '../api/requests/smesherState';
+import { IdentityStateInfo } from '../api/schemas/smesherStates';
+import SortOrder from '../api/sortOrder';
+import { fromBase64 } from '../utils/base64';
 import { SECOND } from '../utils/constants';
+import { toHexString } from '../utils/hexString';
+import {
+  getEpochByLayer,
+  getEpochStartTime,
+  getLayerByTime,
+} from '../utils/timeline';
 
 import createDynamicStore, {
-  createViewOnlyDynamicStore,
   getDynamicStoreDefaults,
 } from './utils/createDynamicStore';
 import useNetworkInfo from './useNetworkInfo';
 import useSmesherConnection from './useSmesherConnection';
 
-const useSmesherStateStore = createDynamicStore<SmesherIdentities>();
+// How many epochs to fetch from history
+const EPOCHS_IN_HISTORY = 20;
 
-const useSmesherStates = () => {
+const useSmesherStateStore = createDynamicStore<IdentityStateInfo[]>();
+
+const useSmesherStatesCore = () => {
   const store = useSmesherStateStore();
   const { data: netInfo } = useNetworkInfo();
   const { getConnection } = useSmesherConnection();
   const rpc = getConnection();
+  const [fetchedRange, setFetchedRange] = useState<[Date, Date]>([
+    new Date(),
+    new Date(),
+  ]);
 
-  const { setData } = store;
+  const { setData, data } = store;
 
   const fetcher = useMemo(
     () =>
-      fetchSmesherStatesWithCallback((newStates) =>
+      fetchSmesherStatesWithCallback((next) =>
         setData((prev) => {
-          const res = prev ? mergeSmesherStates(prev, newStates) : newStates;
+          const res = prev ? [...prev, ...next] : next;
+          const first = res[0];
+          const last = res[res.length - 1];
+          if (first && last) {
+            // Because it might be fetched in ASC and DESC order
+            // We need to store dates in the correct order
+            // [Oldest date, Recent date]
+            const firstTime = new Date(first.time);
+            const lastTime = new Date(last.time);
+            setFetchedRange(
+              firstTime < lastTime
+                ? [firstTime, lastTime]
+                : [lastTime, firstTime]
+            );
+          }
           return res;
         })
       ),
@@ -37,24 +62,99 @@ const useSmesherStates = () => {
   );
 
   useEffect(() => {
-    // let ival: ReturnType<typeof setInterval> | null = null;
+    // Fetch events from history
     let timeout: ReturnType<typeof setTimeout> | null = null;
 
-    if (fetcher && rpc && netInfo?.layerDuration) {
-      // ival = setInterval(() => fetcher(rpc), 30 * SECOND);
-      timeout = setTimeout(() => fetcher(rpc), 5 * SECOND);
+    if (fetcher && rpc && netInfo) {
+      const currentLayerByTime = getLayerByTime(
+        netInfo.layerDuration,
+        netInfo.genesisTime,
+        Date.now()
+      );
+      const currentEpoch = getEpochByLayer(
+        netInfo.layersPerEpoch,
+        currentLayerByTime
+      );
+      const epochRangeLimit = Math.max(currentEpoch - EPOCHS_IN_HISTORY, 0);
+      const epochRangeLimitTime =
+        getEpochStartTime(
+          netInfo.layerDuration,
+          netInfo.layersPerEpoch,
+          epochRangeLimit
+        ) + netInfo.genesisTime;
+      const fromDate = new Date(epochRangeLimitTime);
+      timeout = setTimeout(
+        () => fetcher(rpc, SortOrder.ASC, new Date(), fromDate),
+        5 * SECOND
+      );
     }
+
     return () => {
-      // if (ival) clearInterval(ival);
       if (timeout) clearTimeout(timeout);
     };
   }, [fetcher, netInfo, rpc]);
-  return useMemo(() => createViewOnlyDynamicStore(store), [store]);
+
+  useEffect(() => {
+    // Fetch recent events
+    let ival: ReturnType<typeof setInterval> | null = null;
+    if (fetcher && rpc && netInfo) {
+      ival = setInterval(() => {
+        fetcher(rpc, SortOrder.ASC, new Date(), fetchedRange[1]);
+      }, netInfo.layerDuration * SECOND);
+    }
+    return () => {
+      if (ival) clearInterval(ival);
+    };
+  }, [fetchedRange, fetcher, netInfo, rpc]);
+
+  const statesByIdentity = useMemo(
+    () =>
+      data &&
+      data.reduce((acc, item) => {
+        const id = toHexString(fromBase64(item.smesher));
+        const prevItems = acc[id];
+        acc[id] = prevItems ? [...prevItems, item] : [item];
+        return acc;
+      }, {} as Record<string, IdentityStateInfo[]>),
+    [data]
+  );
+
+  return useMemo(
+    () => ({
+      data: statesByIdentity,
+      error: store.error,
+      lastUpdate: store.lastUpdate,
+    }),
+    [statesByIdentity, store]
+  );
 };
+
+const useSmesherStates = singletonHook(
+  getDynamicStoreDefaults(),
+  useSmesherStatesCore
+);
 
 export const useSmesherIds = () => {
   const { data } = useSmesherStates();
-  return useMemo(() => data && Object.keys(data), [data]);
+  const idsRef = useRef(new Set<string>());
+  const [ids, setIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!data) return;
+
+    let changed = false;
+    Object.keys(data).forEach((id) => {
+      if (!idsRef.current.has(id)) {
+        idsRef.current.add(id);
+        changed = true;
+      }
+    });
+    if (changed) {
+      setIds(Array.from(idsRef.current));
+    }
+  }, [data]);
+
+  return ids;
 };
 
-export default singletonHook(getDynamicStoreDefaults(), useSmesherStates);
+export default useSmesherStates;

--- a/src/store/useSmesherStates.ts
+++ b/src/store/useSmesherStates.ts
@@ -25,28 +25,25 @@ const useSmesherStates = () => {
 
   const { setData } = store;
 
-  const fetcher = useMemo(() => {
-    console.log('fetcher called');
-    return fetchSmesherStatesWithCallback((newStates) =>
-      setData((prev) => {
-        console.time('merge');
-        const res = prev ? mergeSmesherStates(prev, newStates) : newStates;
-        console.timeEnd('merge');
-        return res;
-      })
-    );
-  }, [setData]);
+  const fetcher = useMemo(
+    () =>
+      fetchSmesherStatesWithCallback((newStates) =>
+        setData((prev) => {
+          const res = prev ? mergeSmesherStates(prev, newStates) : newStates;
+          return res;
+        })
+      ),
+    [setData]
+  );
 
   useEffect(() => {
-    console.log('use effect!');
     // let ival: ReturnType<typeof setInterval> | null = null;
     let timeout: ReturnType<typeof setTimeout> | null = null;
 
     if (fetcher && rpc && netInfo?.layerDuration) {
-      // ival = setInterval(() => fetcher(rpc), netInfo.layerDuration * SECOND);
+      // ival = setInterval(() => fetcher(rpc), 30 * SECOND);
       timeout = setTimeout(() => fetcher(rpc), 5 * SECOND);
     }
-    console.log('...');
     return () => {
       // if (ival) clearInterval(ival);
       if (timeout) clearTimeout(timeout);

--- a/src/store/utils/createDynamicStore.ts
+++ b/src/store/utils/createDynamicStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-type SetterFn<T> = (prev: T | null) => T;
+export type SetterFn<T> = (prev: T | null) => T;
 
 export type DynamicStore<T> = {
   data: T | null;

--- a/src/store/utils/createDynamicStore.ts
+++ b/src/store/utils/createDynamicStore.ts
@@ -1,10 +1,12 @@
 import { create } from 'zustand';
 
+type SetterFn<T> = (prev: T | null) => T;
+
 export type DynamicStore<T> = {
   data: T | null;
   error: Error | null;
   lastUpdate: number;
-  setData: (data: T) => void;
+  setData: (arg: T | SetterFn<T>) => void;
   setError: (error: Error, noLastUpdate?: boolean) => void;
 };
 
@@ -19,7 +21,17 @@ const createDynamicStore = <T>() =>
     data: null,
     error: null,
     lastUpdate: 0,
-    setData: (data: T) => set({ data, error: null, lastUpdate: Date.now() }),
+    setData: (arg: T | SetterFn<T>) => {
+      if (typeof arg === 'function') {
+        set((state) => ({
+          data: (arg as SetterFn<T>)(state.data),
+          error: null,
+          lastUpdate: Date.now(),
+        }));
+      } else {
+        set({ data: arg as T, error: null, lastUpdate: Date.now() });
+      }
+    },
     setError: (error: Error, noLastUpdate = false) =>
       set({
         error,

--- a/src/types/networks.ts
+++ b/src/types/networks.ts
@@ -18,3 +18,7 @@ export type NodeStatus = {
   processedLayer: number;
   latestLayer: number;
 };
+
+export type Activations = {
+  count: number;
+};

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -45,7 +45,35 @@ export type TimelineItem<T extends AnyTimelineDetails = AnyTimelineDetails> =
     data: ItemData<T>;
   };
 
-export const isEventDetails = (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isTimelineItem = (i: any): i is TimelineItem =>
+  !!i.data.title && Object.hasOwn(i.data, 'type');
+
+export const isEventItem = (i: TimelineItem): i is TimelineItem<EventDetails> =>
+  isTimelineItem(i) &&
+  Object.hasOwn(i.data, 'details') &&
+  i.data.type === TimelineItemType.Event;
+
+export const isEpochItem = (i: TimelineItem): i is TimelineItem<EpochDetails> =>
+  isTimelineItem(i) &&
+  Object.hasOwn(i.data, 'details') &&
+  i.data.type === TimelineItemType.Epoch;
+
+export const isLayerItem = (i: TimelineItem): i is TimelineItem<LayerDetails> =>
+  isTimelineItem(i) &&
+  Object.hasOwn(i.data, 'details') &&
+  i.data.type === TimelineItemType.Layer;
+
+export const isCycleGapItem = (
   i: TimelineItem
-): i is TimelineItem<EventDetails> =>
-  !!i.data.title && Object.hasOwn(i.data, 'details');
+): i is TimelineItem<CycleGapDetails> =>
+  isTimelineItem(i) &&
+  Object.hasOwn(i.data, 'details') &&
+  i.data.type === TimelineItemType.CycleGap;
+
+export const isPoetRoundItem = (
+  i: TimelineItem
+): i is TimelineItem<PoetRoundDetails> =>
+  isTimelineItem(i) &&
+  Object.hasOwn(i.data, 'details') &&
+  i.data.type === TimelineItemType.PoetRound;


### PR DESCRIPTION
It contains a bunch of UI improvements:
- **fetch all smesher events, not only first 100**
- mark eligible layers and epochs that should have rewards (if everything will go well)
- mark epoch as failed, if at least one proposal was not published
- mark passed registered PoET round without PoET proof as failed
- added default status message in the Identities table (if it just started, no events yet)
- follow the same color rules in the Identities table for layer eligibilities
- replace JSON stringified item details in the tooltip to something prettier

Added some improvements:
- Use newer SmeshingIdentitiesService/States API (and fetch events by timestamps)
- Fix: do not re-fetch already fetched rewards
- Optimised GUI rendering