### PR TITLE
Check for Smesher Service version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ To help you build more efficient commit messages, you can use the [commitizen](h
 ```bash
 yarn cz
 ```
+
+## Development
+
+### Environment variables
+
+For better developer experience there are some ENV variables that is available ONLY for dev mode (`yarn dev`) and won't be used in the built code due to the security reasons.
+
+- `APP_VERSION` — SemVer of Smesher App to be used instead of one in `package.json`
+- `VERSIONS_JSON_URL` — full URL to the file that maps minimal Smesher Service Version to the latest Smesher App Version
+- `OFFICIAL_HOSTED_URL` — the first segment of URL (protocol and hostname), will be used for proposal to switch to another hosted version

--- a/global.ts
+++ b/global.ts
@@ -1,0 +1,3 @@
+export const VERSIONS_JSON_URL =
+  'http://configs.spacemesh.network/smesher-app.versions.json';
+export const OFFICIAL_HOSTED_URL = 'https://smesher-beta.spacemesh.network/';

--- a/global.ts
+++ b/global.ts
@@ -1,3 +1,3 @@
 export const VERSIONS_JSON_URL =
-  'http://configs.spacemesh.network/smesher-app.versions.json';
+  'https://configs.spacemesh.network/smesher-app.versions.json';
 export const OFFICIAL_HOSTED_URL = 'https://smesher-beta.spacemesh.network/';

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-qr-code": "^2.0.14",
     "react-router-dom": "^6.22.3",
     "react-singleton-hook": "^4.0.1",
+    "semver": "^7.7.1",
     "vis-data": "^7.1.9",
     "vis-timeline": "^7.7.3",
     "xss": "^1.0.15",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "ts-jest": "^29.0.5",
     "typescript": "^4.5.5",
     "vite": "^4.5.5",
+    "vite-plugin-environment": "^1.1.3",
     "vite-plugin-node-polyfills": "^0.22.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smesher-app",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Kirill Shumilov",
     "email": "kirill@spacemesh.io",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smesher-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Kirill Shumilov",
     "email": "kirill@spacemesh.io",

--- a/src/api/requests/version.ts
+++ b/src/api/requests/version.ts
@@ -1,0 +1,33 @@
+import fetchJSON from '../../utils/fetchJSON';
+import { parseResponse } from '../schemas/error';
+import {
+  VersionResponseSchema,
+  VersionsMapResponse,
+  VersionsMapResponseSchema,
+} from '../schemas/version';
+
+// Example of output:
+// Promise.resolve('1.5.0');
+export const fetchSmesherVersion = (rpc: string) =>
+  fetchJSON(`${rpc}/spacemesh.v2beta1.SmeshingService/Version`, {
+    method: 'GET',
+  })
+    .then(parseResponse(VersionResponseSchema))
+    .then(({ version }) => version);
+
+// Example of output:
+// Promise.resolve([
+//   ['0.0.1', '0.3.0'],
+//   ['1.4.5', '0.5.3'],
+//   ['2.0.0', '1.0.0'],
+// ]);
+// First column is Smesher Service minimal version
+// Second column is Smesher App maximal version
+// So if User is using Smesher Service v1.5.2 — it is expected
+// to have Smesher App version >0.3.0 and <=0.5.3
+// If Smesher App is less than specified version here —
+// it will propose to update the app
+export const fetchVersionsMap = (url: string): Promise<VersionsMapResponse> =>
+  fetchJSON(url, {
+    method: 'GET',
+  }).then(parseResponse(VersionsMapResponseSchema));

--- a/src/api/schemas/version.ts
+++ b/src/api/schemas/version.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod';
+
+export const VersionResponseSchema = z.object({
+  version: z.string(),
+});
+
+export const VersionsMapResponseSchema = z.array(
+  z.tuple([z.string(), z.string()])
+);
+
+export type VersionsMapResponse = z.infer<typeof VersionsMapResponseSchema>;

--- a/src/components/VersionMismatch.tsx
+++ b/src/components/VersionMismatch.tsx
@@ -1,0 +1,135 @@
+import { useEffect } from 'react';
+
+import {
+  Button,
+  Icon,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import {
+  IconBrandGithub,
+  IconExclamationCircleFilled,
+  IconThumbUpFilled,
+} from '@tabler/icons-react';
+
+import useVersions from '../store/useVersions';
+
+function VersionMismatch(): JSX.Element | null {
+  const { smesherVersion, versionCheck } = useVersions();
+  const disclosure = useDisclosure();
+
+  const { onOpen } = disclosure;
+  useEffect(() => {
+    if (!versionCheck?.supported) {
+      onOpen();
+    }
+  }, [onOpen, versionCheck?.supported]);
+
+  if (!versionCheck || (versionCheck.supported && !versionCheck.hasUpdate))
+    return null;
+
+  const url = `https://smesher-alpha.spacemesh.network/v${
+    versionCheck.actual[1] ? `${versionCheck.actual[1]}/` : ''
+  }`;
+
+  return (
+    <>
+      <Button
+        variant="link"
+        fontWeight="normal"
+        color={versionCheck.hasUpdate ? 'brand.green' : 'brand.yellow'}
+        ml={2}
+        onClick={disclosure.onOpen}
+        lineHeight={0}
+      >
+        [
+        <Icon
+          mb={-0.5}
+          as={
+            versionCheck.hasUpdate
+              ? IconThumbUpFilled
+              : IconExclamationCircleFilled
+          }
+          mr={0.5}
+        />
+        {versionCheck.hasUpdate
+          ? 'New Version Available'
+          : 'Unsupported Smesher Version'}
+        ]
+      </Button>
+      <Modal
+        isCentered
+        size="xl"
+        isOpen={disclosure.isOpen}
+        onClose={disclosure.onClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            {versionCheck.hasUpdate
+              ? `Smesher App v${versionCheck.expected[1]} is available`
+              : `Smesher Service v${smesherVersion} is not supported`}
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            {versionCheck.hasUpdate ? (
+              <Text mb={3}>
+                Current Application version: v{versionCheck.actual[1]}
+                <br />
+                Latest Application version: v{versionCheck.expected[1]}
+              </Text>
+            ) : (
+              <Text mb={3}>
+                Current Application version: v{versionCheck.actual[1]}
+                <br />
+                Required Application version: v{versionCheck.expected[1]}
+              </Text>
+            )}
+            <Text mb={2}>
+              Please switch to the Smesher App v{versionCheck.expected[1]} to
+              have all the features working correctly by updating your local
+              Smesher App or switch to the publicly hosted version.
+            </Text>
+          </ModalBody>
+
+          <ModalFooter justifyContent="space-between">
+            <Button
+              as={Link}
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              variant="green"
+              size="sm"
+            >
+              To the hosted version
+            </Button>
+            <Button
+              as={Link}
+              href="https://github.com/spacemeshos/smesher-app/releases"
+              target="_blank"
+              rel="noreferrer"
+              variant="white"
+              size="sm"
+            >
+              <Icon as={IconBrandGithub} size="sm" mr={1} />
+              GitHub
+            </Button>
+            <Button variant="white" size="sm" onClick={disclosure.onClose}>
+              Stay on that version
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+export default VersionMismatch;

--- a/src/components/VersionMismatch.tsx
+++ b/src/components/VersionMismatch.tsx
@@ -70,7 +70,7 @@ function VersionMismatch(): JSX.Element | null {
         onClick={refresh}
         lineHeight={0}
       >
-        [v{versionCheck?.actual[0]}]
+        [{versionCheck?.actual[0]}]
       </Button>
     );
   }
@@ -115,7 +115,7 @@ function VersionMismatch(): JSX.Element | null {
           <ModalHeader>
             {versionCheck.hasUpdate
               ? `Smesher App v${versionCheck.expected[1]} is available`
-              : `Smesher Service v${smesherVersion} is not supported`}
+              : `Smesher Service ${smesherVersion} is not supported`}
           </ModalHeader>
           <ModalCloseButton />
           <ModalBody>

--- a/src/components/VersionMismatch.tsx
+++ b/src/components/VersionMismatch.tsx
@@ -11,6 +11,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Spinner,
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
@@ -23,7 +24,8 @@ import {
 import useVersions from '../store/useVersions';
 
 function VersionMismatch(): JSX.Element | null {
-  const { smesherVersion, versionCheck } = useVersions();
+  const { loading, error, refresh, smesherVersion, versionCheck } =
+    useVersions();
   const disclosure = useDisclosure();
 
   const { onOpen } = disclosure;
@@ -33,11 +35,48 @@ function VersionMismatch(): JSX.Element | null {
     }
   }, [onOpen, versionCheck?.supported]);
 
-  if (!versionCheck || (versionCheck.supported && !versionCheck.hasUpdate))
-    return null;
+  if (loading) {
+    return (
+      <Spinner
+        title="Checking version..."
+        color="brand.yellow"
+        size="xs"
+        ml={2}
+      />
+    );
+  }
 
-  const url = `https://smesher-alpha.spacemesh.network/v${
-    versionCheck.actual[1] ? `${versionCheck.actual[1]}/` : ''
+  if (error) {
+    return (
+      <Button
+        variant="link"
+        color="brand.red"
+        ml={2}
+        onClick={refresh}
+        lineHeight={0}
+      >
+        [Cannot check version. Retry?]
+      </Button>
+    );
+  }
+
+  if (!versionCheck || (versionCheck.supported && !versionCheck.hasUpdate)) {
+    // All good: Render "Refresh button"
+    return (
+      <Button
+        variant="link"
+        color="brand.green"
+        ml={2}
+        onClick={refresh}
+        lineHeight={0}
+      >
+        [v{versionCheck?.actual[0]}]
+      </Button>
+    );
+  }
+
+  const url = `https://smesher-alpha.spacemesh.network/${
+    versionCheck.actual[1] ? `version/${versionCheck.actual[1]}/` : ''
   }`;
 
   return (

--- a/src/components/VersionMismatch.tsx
+++ b/src/components/VersionMismatch.tsx
@@ -22,6 +22,7 @@ import {
 } from '@tabler/icons-react';
 
 import useVersions from '../store/useVersions';
+import { HOSTED_APP_URL } from '../utils/constants';
 
 function VersionMismatch(): JSX.Element | null {
   const { loading, error, refresh, smesherVersion, versionCheck } =
@@ -75,8 +76,8 @@ function VersionMismatch(): JSX.Element | null {
     );
   }
 
-  const url = `https://smesher-beta.spacemesh.network/${
-    versionCheck.actual[1] ? `version/${versionCheck.actual[1]}/` : ''
+  const url = `${HOSTED_APP_URL}/${
+    versionCheck.actual[1] ? `version/${versionCheck.expected[1]}/` : ''
   }`;
 
   return (

--- a/src/components/VersionMismatch.tsx
+++ b/src/components/VersionMismatch.tsx
@@ -75,7 +75,7 @@ function VersionMismatch(): JSX.Element | null {
     );
   }
 
-  const url = `https://smesher-alpha.spacemesh.network/${
+  const url = `https://smesher-beta.spacemesh.network/${
     versionCheck.actual[1] ? `version/${versionCheck.actual[1]}/` : ''
   }`;
 

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -31,6 +31,7 @@ import OptionalError from '../components/dashboard/OptionalError';
 // eslint-disable-next-line max-len
 import SmesherIdentityDetails from '../components/dashboard/SmesherIdentityDetails';
 import SmeshingTimeline from '../components/timeline/SmeshingTimeline';
+import VersionMismatch from '../components/VersionMismatch';
 import useTimelineData from '../hooks/useTimelineData';
 import useActivations from '../store/useActivations';
 import useEligibilities from '../store/useEligibilities';
@@ -41,6 +42,7 @@ import useProposals from '../store/useProposals';
 import useRewards from '../store/useRewards';
 import useSmesherConnection from '../store/useSmesherConnection';
 import useSmesherStates from '../store/useSmesherStates';
+import useVersions from '../store/useVersions';
 import { HexString } from '../types/common';
 import { sortHexString } from '../utils/hexString';
 import { formatSmidge } from '../utils/smh';
@@ -57,7 +59,8 @@ function DashboardScreen(): JSX.Element {
   const Proposals = useProposals();
   const Rewards = useRewards();
   const navigate = useNavigate();
-  const data = useTimelineData();
+  const Timeline = useTimelineData();
+  const { versionCheck } = useVersions();
 
   const disconnect = () => {
     setConnection('');
@@ -121,6 +124,16 @@ function DashboardScreen(): JSX.Element {
 
   const [forceClosed, setForceClosed] = useState(false);
 
+  const netStatus = getStatusByStore(NetInfo);
+  const apiStatus =
+    netStatus === 'ok'
+      ? versionCheck
+        ? versionCheck.supported
+          ? 'ok'
+          : 'pending'
+        : 'ok'
+      : 'pending';
+
   return (
     <>
       <Modal
@@ -173,7 +186,7 @@ function DashboardScreen(): JSX.Element {
         overflow="auto"
       >
         <Box mb={2} w="100%">
-          <StatusBulb status={getStatusByStore(NetInfo)} mr={2} />
+          <StatusBulb status={apiStatus} mr={2} />
           Connected to {getConnection()}
           {NetInfo.error && (
             <Button
@@ -186,6 +199,7 @@ function DashboardScreen(): JSX.Element {
               [Refresh]
             </Button>
           )}
+          <VersionMismatch />
           <Button
             variant="link"
             fontWeight="normal"
@@ -302,13 +316,13 @@ function DashboardScreen(): JSX.Element {
                               <Box
                                 as="span"
                                 className={`id-marker ${
-                                  data.smesherMessages[id]?.type ?? ''
+                                  Timeline.smesherMessages[id]?.type ?? ''
                                 }`}
                                 mr={1}
                               >
                                 {index + 1}
                               </Box>
-                              {data.smesherMessages[id]?.message ??
+                              {Timeline.smesherMessages[id]?.message ??
                                 'Waiting for the smesher events...'}
                             </Text>
 

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -125,6 +125,7 @@ function DashboardScreen(): JSX.Element {
   const [forceClosed, setForceClosed] = useState(false);
 
   const netStatus = getStatusByStore(NetInfo);
+  /* eslint-disable no-nested-ternary */
   const apiStatus =
     netStatus === 'ok'
       ? versionCheck
@@ -133,6 +134,7 @@ function DashboardScreen(): JSX.Element {
           : 'pending'
         : 'ok'
       : 'pending';
+  /* eslint-enable no-nested-ternary */
 
   return (
     <>

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -23,6 +23,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 
+import { version } from '../../package.json';
 import StatusBulb, { getStatusByStore } from '../components/basic/StatusBulb';
 import TableContents from '../components/basic/TableContents';
 import NetworkInfo from '../components/dashboard/NetworkInfo';
@@ -187,7 +188,17 @@ function DashboardScreen(): JSX.Element {
         alignItems="flex-start"
         overflow="auto"
       >
-        <Box mb={2} w="100%">
+        <Box
+          pos="absolute"
+          top={0}
+          right={0}
+          mt={2}
+          mr={4}
+          title="Smesher app version"
+        >
+          v{version}
+        </Box>
+        <Box mb={2} w="100%" pr={12}>
           <StatusBulb status={apiStatus} mr={2} />
           Connected to {getConnection()}
           {NetInfo.error && (

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -23,7 +23,6 @@ import {
   Text,
 } from '@chakra-ui/react';
 
-import { version } from '../../package.json';
 import StatusBulb, { getStatusByStore } from '../components/basic/StatusBulb';
 import TableContents from '../components/basic/TableContents';
 import NetworkInfo from '../components/dashboard/NetworkInfo';
@@ -45,6 +44,7 @@ import useSmesherConnection from '../store/useSmesherConnection';
 import useSmesherStates from '../store/useSmesherStates';
 import useVersions from '../store/useVersions';
 import { HexString } from '../types/common';
+import { APP_VERSION } from '../utils/constants';
 import { sortHexString } from '../utils/hexString';
 import { formatSmidge } from '../utils/smh';
 
@@ -196,7 +196,7 @@ function DashboardScreen(): JSX.Element {
           mr={4}
           title="Smesher app version"
         >
-          v{version}
+          v{APP_VERSION}
         </Box>
         <Box mb={2} w="100%" pr={12}>
           <StatusBulb status={apiStatus} mr={2} />

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -12,9 +12,9 @@ import {
 import { O } from '@mobily/ts-belt';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 
-import { version } from '../../package.json';
 import Logo from '../components/basic/Logo';
 import useSmesherConnection from '../store/useSmesherConnection';
+import { APP_VERSION } from '../utils/constants';
 import { normalizeURL } from '../utils/url';
 
 function WelcomeScreen(): JSX.Element {
@@ -109,7 +109,7 @@ function WelcomeScreen(): JSX.Element {
         color="gray.500"
         textAlign="center"
       >
-        Smesher App v{version}
+        Smesher App v{APP_VERSION}
       </Text>
     </Flex>
   );

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { O } from '@mobily/ts-belt';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 
+import { version } from '../../package.json';
 import Logo from '../components/basic/Logo';
 import useSmesherConnection from '../store/useSmesherConnection';
 import { normalizeURL } from '../utils/url';
@@ -100,6 +101,16 @@ function WelcomeScreen(): JSX.Element {
           </Button>
         </Form>
       </Flex>
+
+      <Text
+        pos="absolute"
+        bottom={10}
+        fontSize="sm"
+        color="gray.500"
+        textAlign="center"
+      >
+        Smesher App v{version}
+      </Text>
     </Flex>
   );
 }

--- a/src/store/useVersions.ts
+++ b/src/store/useVersions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { singletonHook } from 'react-singleton-hook';
 import semver from 'semver';
 

--- a/src/store/useVersions.ts
+++ b/src/store/useVersions.ts
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from 'react';
+import { singletonHook } from 'react-singleton-hook';
+import semver from 'semver';
+
+import { version as currentAppVersion } from '../../package.json';
+import { fetchSmesherVersion, fetchVersionsMap } from '../api/requests/version';
+
+import useSmesherConnection from './useSmesherConnection';
+
+const APP_VERSIONS_MAP_URL =
+  'https://configs.spacemesh.network/smesher-app.versions.json';
+
+type VersionInfo = [
+  // Version of Smesher Service fetched via API
+  string,
+  // Supported version of the app [minimal] or [minimal, maximal]
+  string
+];
+
+export interface VersionCheck {
+  supported: boolean;
+  hasUpdate: boolean;
+  actual: VersionInfo;
+  expected: VersionInfo;
+}
+
+const checkVersion = async (version: string): Promise<VersionCheck> => {
+  const versions = await fetchVersionsMap(APP_VERSIONS_MAP_URL);
+
+  const idxBySmesherVersion = versions.findIndex((x, idx) => {
+    const isGte = semver.gte(version, x[0] ?? '');
+    const next = versions[idx + 1];
+    const isUpToNext = next ? semver.lt(version, next[0] ?? '') : true;
+    return isGte && isUpToNext;
+  });
+
+  const actual: VersionInfo = [version, currentAppVersion];
+  const expected = versions[idxBySmesherVersion];
+  if (!expected) {
+    throw new Error(
+      // eslint-disable-next-line max-len
+      `Cannot find the corresponding version for the current Smesher version: ${version}`
+    );
+  }
+
+  const prevFrontEndVersion = versions[idxBySmesherVersion - 1]?.[1];
+  const hasUpdate =
+    semver.lt(currentAppVersion, expected[1]) &&
+    (prevFrontEndVersion
+      ? semver.gt(currentAppVersion, prevFrontEndVersion)
+      : true);
+  const supported = prevFrontEndVersion
+    ? semver.satisfies(
+        currentAppVersion,
+        `>${prevFrontEndVersion} <=${expected[1]}`
+      )
+    : semver.satisfies(currentAppVersion, `<=${expected[1]}`);
+
+  return {
+    supported,
+    hasUpdate,
+    actual,
+    expected,
+  };
+};
+
+export const getHostedAppUrl = (hostedVersion: string): string =>
+  `https://smesher-alpha.spacemesh.network/${hostedVersion}/#/dash`;
+
+const useVersions = () => {
+  const { getConnection } = useSmesherConnection();
+  const [smesherVersion, setSmesherVersion] = useState<string | null>(null);
+  const [versionCheck, setVersionCheck] = useState<VersionCheck | null>(null);
+  const rpc = getConnection();
+
+  useEffect(() => {
+    if (rpc) {
+      fetchSmesherVersion(rpc).then((version) => {
+        setSmesherVersion(version);
+      });
+    }
+  }, [rpc, setSmesherVersion]);
+
+  useEffect(() => {
+    if (!smesherVersion) return;
+
+    checkVersion(smesherVersion)
+      .then((version) => {
+        setVersionCheck(version);
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
+  }, [smesherVersion]);
+
+  return useMemo(
+    () => ({
+      smesherVersion,
+      versionCheck,
+      currentAppVersion,
+    }),
+    [smesherVersion, versionCheck]
+  );
+};
+
+export default singletonHook(
+  { smesherVersion: null, versionCheck: null, currentAppVersion: '' },
+  useVersions
+);

--- a/src/store/useVersions.ts
+++ b/src/store/useVersions.ts
@@ -2,13 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { singletonHook } from 'react-singleton-hook';
 import semver from 'semver';
 
-import { version as currentAppVersion } from '../../package.json';
 import { fetchSmesherVersion, fetchVersionsMap } from '../api/requests/version';
+import { APP_VERSION, VERSIONS_JSON_URL } from '../utils/constants';
 
 import useSmesherConnection from './useSmesherConnection';
-
-const APP_VERSIONS_MAP_URL =
-  'https://configs.spacemesh.network/smesher-app.versions.json';
 
 type VersionInfo = [
   // Version of Smesher Service fetched via API
@@ -34,7 +31,7 @@ const checkVersion = async (inputVersion: string): Promise<VersionCheck> => {
   const prefix = getPrefix(inputVersion);
   const version = removePrefix(prefix, inputVersion);
 
-  const versions = await fetchVersionsMap(APP_VERSIONS_MAP_URL);
+  const versions = await fetchVersionsMap(VERSIONS_JSON_URL);
   const versionsByPrefix = versions
     .filter(([v]) => getPrefix(v) === prefix)
     .map(([s, f]) => [removePrefix(prefix, s), f]);
@@ -46,7 +43,7 @@ const checkVersion = async (inputVersion: string): Promise<VersionCheck> => {
     return isGte && isUpToNext;
   });
 
-  const actual: VersionInfo = [inputVersion, currentAppVersion];
+  const actual: VersionInfo = [inputVersion, APP_VERSION];
   const expected = versions[idxBySmesherVersion];
   if (!expected) {
     throw new Error(
@@ -57,16 +54,11 @@ const checkVersion = async (inputVersion: string): Promise<VersionCheck> => {
 
   const prevFrontEndVersion = versions[idxBySmesherVersion - 1]?.[1];
   const hasUpdate =
-    semver.lt(currentAppVersion, expected[1]) &&
-    (prevFrontEndVersion
-      ? semver.gt(currentAppVersion, prevFrontEndVersion)
-      : true);
+    semver.lt(APP_VERSION, expected[1]) &&
+    (prevFrontEndVersion ? semver.gt(APP_VERSION, prevFrontEndVersion) : true);
   const supported = prevFrontEndVersion
-    ? semver.satisfies(
-        currentAppVersion,
-        `>${prevFrontEndVersion} <=${expected[1]}`
-      )
-    : semver.satisfies(currentAppVersion, `<=${expected[1]}`);
+    ? semver.satisfies(APP_VERSION, `>${prevFrontEndVersion} <=${expected[1]}`)
+    : semver.satisfies(APP_VERSION, `<=${expected[1]}`);
 
   return {
     supported,
@@ -116,7 +108,6 @@ const useVersions = () => {
       refresh,
       smesherVersion,
       versionCheck,
-      currentAppVersion,
       error,
     }),
     [error, refresh, smesherVersion, versionCheck, loading]
@@ -130,7 +121,6 @@ export default singletonHook(
     error: null,
     smesherVersion: null,
     versionCheck: null,
-    currentAppVersion: '',
   },
   useVersions
 );

--- a/src/store/useVersions.ts
+++ b/src/store/useVersions.ts
@@ -76,9 +76,6 @@ const checkVersion = async (inputVersion: string): Promise<VersionCheck> => {
   };
 };
 
-export const getHostedAppUrl = (hostedVersion: string): string =>
-  `https://smesher-alpha.spacemesh.network/${hostedVersion}/#/dash`;
-
 const useVersions = () => {
   const { getConnection } = useSmesherConnection();
   const [smesherVersion, setSmesherVersion] = useState<string | null>(null);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,12 +1,32 @@
+import * as GLOBAL from '../../global';
 import { version } from '../../package.json';
 
-// Pathname where App is hosted
-export const BASE_PATH = `/version/${version}`;
+import { normalizeURL } from './url';
 
+// Env getters
+export const VERSIONS_JSON_URL = normalizeURL(
+  process.env.VERSIONS_JSON_URL || GLOBAL.VERSIONS_JSON_URL
+);
+
+export const HOSTED_APP_URL = normalizeURL(
+  process.env.OFFICIAL_HOSTED_URL || GLOBAL.OFFICIAL_HOSTED_URL
+);
+
+export const APP_VERSION = process.env.APP_VERSION || version;
+
+//
+// Pathname where App is hosted
+//
+export const BASE_PATH = `/version/${APP_VERSION}`;
+
+//
 // Time
+//
 export const SECOND = 1000;
 export const MINUTE = 60 * SECOND;
 export const HOUR = 60 * MINUTE;
 
+//
 // Intervals
+//
 export const FETCH_RETRY = 30 * SECOND;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,22 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
+import EnvironmentPlugin from 'vite-plugin-environment';
 
+import { version } from './package.json';
+import { OFFICIAL_HOSTED_URL, VERSIONS_JSON_URL } from './global';
 import { BASE_PATH } from './src/utils/constants';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   base: BASE_PATH,
   plugins: [
+    EnvironmentPlugin(
+      mode === 'development' ? {
+      'VERSIONS_JSON_URL': VERSIONS_JSON_URL,
+      'OFFICIAL_HOSTED_URL': OFFICIAL_HOSTED_URL,
+      'APP_VERSION': version,
+    } : {}),
     react(),
     nodePolyfills({
       include: ['buffer'],
@@ -28,4 +37,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9081,6 +9081,11 @@ vis-timeline@^7.7.3:
   resolved "https://registry.yarnpkg.com/vis-timeline/-/vis-timeline-7.7.3.tgz#79434eb3029169bff8de1b5012aa5c29786d6594"
   integrity sha512-hGMzTttdOFWaw1PPlJuCXU2/4UjnsIxT684Thg9fV6YU1JuKZJs3s3BrJgZ4hO3gu5i1hsMe1YIi96o+eNT0jg==
 
+vite-plugin-environment@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz#d01a04abb2f69730a4866c9c9db51d3dab74645b"
+  integrity sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==
+
 vite-plugin-node-polyfills@^0.22.0:
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.22.0.tgz#d0afcf82eb985fc02244620d7cec1ddd1c6e0864"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8226,6 +8226,11 @@ semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
+semver@^7.7.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -8552,7 +8557,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8565,13 +8570,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9234,16 +9232,7 @@ word-wrap@^1.0.3, word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
It closes #17.

---

URL to versions.json file is hard-coded and most likely should be changed.

That file should have a format:
```
[
  ['0.0.1', '0.3.0'],
  ['1.4.5', '0.5.3'],
  ['2.0.0', '1.0.0'],
]
```

- First column is Smesher Service minimal version
- Second column is Smesher App latest version

In other words, for Smesher Service `>=1.4.5 <2.0.0` valid Smesher App versions are `>0.3.0 <= 0.5.3`.

Example:
If User is using Smesher Service `v1.5.2`, than it is expected to have Smesher App version `>0.3.0` and `<=0.5.3`.
Therefore, if App version is...
- is equal to v0.5.3 — nothing happens.
- is in the range, but not the latest — propose to update
- is out of the range — tell that App does not support that version of Smesher Service and User have to switch

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/e467a637-5403-481a-adde-b0f091d59195" />

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/56d8e076-e24c-45a9-9409-9b9b56fc7e1f" />
