### PR TITLE
Add support for multi-version deploy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Build and Release
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 
 jobs:
   deploy:
@@ -12,15 +12,38 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
       - name: Install dependencies and build
         run: |
           yarn
           yarn build
-
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy ./dist --project-name=${{ secrets.CLOUDFLARE_PAGE_PROJECT }}
+  deploy-to-r2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Replace $VERSION in config.ts
+        run: sed -i 's|\$VERSION|${{ github.ref_name }}|g' config.ts
+      - name: Install dependencies and build
+        run: |
+          yarn
+          yarn build
+      - name: Install aws-cli
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
+      - name: upload ./dist to R2
+        run: >
+          aws s3 cp --recursive ./dist
+          s3://${{ secrets.CLOUDFLARE_APP_BUCKET }}/${{ github.ref_name }}
+          --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+            AWS_REGION: us-east-1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Replace $VERSION in config.ts
-        run: sed -i 's|\$VERSION|${{ github.ref_name }}|g' config.ts
+      - id: package-version
+        uses: tyankatsu0105/read-package-version-actions@v1
+      - uses: olegtarasov/get-tag@v2.1
+        id: tagName
+      - name: Tag and version are equals
+        if: ${{ steps.tagName.outputs.tag != steps.package-version.outputs.version }}
+        run: |
+          echo "Tag does not match Version."
+          echo "Tag: ${{ steps.tagName.outputs.tag }}"
+          echo "Version: v${{ steps.package-version.outputs.version }}"
+          exit 1
       - name: Install dependencies and build
         run: |
           yarn

--- a/config.ts
+++ b/config.ts
@@ -1,3 +1,0 @@
-export const global_config = {
-    basePath: '/version/$VERSION',
-};

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,3 @@
+export const global_config = {
+    basePath: '/version/$VERSION',
+};

--- a/src/theme/Fonts.tsx
+++ b/src/theme/Fonts.tsx
@@ -1,31 +1,32 @@
 /* eslint-disable max-len */
 import { Global } from '@emotion/react';
+import { global_config } from '../../config';
 
 function Fonts() {
   return (
     <Global
       styles={`
       /* latin */
-     	@font-face {
+	@font-face {
 				font-family: 'Univers45';
-				src: url('/fonts/Univers LT W01 45 Light.otf') format('opentype');
+				src: url('${global_config.basePath}/fonts/Univers LT W01 45 Light.otf') format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers55';
-				src: url('/fonts/Univers LT W01 55 Roman.otf') format('opentype');
+				src: url('${global_config.basePath}/fonts/Univers LT W01 55 Roman.otf') format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers63';
-				src: url('/fonts/Univers LT W01 63 Bold Extended.otf')
+				src: url('${global_config.basePath}/fonts/Univers LT W01 63 Bold Extended.otf')
 					format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers65';
-				src: url('/fonts/Univers LT W01 65 Bold.otf') format('opentype');
+				src: url('${global_config.basePath}/fonts/Univers LT W01 65 Bold.otf') format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers93';
-				src: url('/fonts/Univers LT W01 93 X Black Ext.otf') format('opentype');
+				src: url('${global_config.basePath}/fonts/Univers LT W01 93 X Black Ext.otf') format('opentype');
 			}
       `}
     />

--- a/src/theme/Fonts.tsx
+++ b/src/theme/Fonts.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import { Global } from '@emotion/react';
-import { global_config } from '../../config';
+
+import { BASE_PATH } from '../utils/constants';
 
 function Fonts() {
   return (
@@ -9,24 +10,24 @@ function Fonts() {
       /* latin */
 	@font-face {
 				font-family: 'Univers45';
-				src: url('${global_config.basePath}/fonts/Univers LT W01 45 Light.otf') format('opentype');
+				src: url('${BASE_PATH}/fonts/Univers LT W01 45 Light.otf') format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers55';
-				src: url('${global_config.basePath}/fonts/Univers LT W01 55 Roman.otf') format('opentype');
+				src: url('${BASE_PATH}/fonts/Univers LT W01 55 Roman.otf') format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers63';
-				src: url('${global_config.basePath}/fonts/Univers LT W01 63 Bold Extended.otf')
+				src: url('${BASE_PATH}/fonts/Univers LT W01 63 Bold Extended.otf')
 					format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers65';
-				src: url('${global_config.basePath}/fonts/Univers LT W01 65 Bold.otf') format('opentype');
+				src: url('${BASE_PATH}/fonts/Univers LT W01 65 Bold.otf') format('opentype');
 			}
 			@font-face {
 				font-family: 'Univers93';
-				src: url('${global_config.basePath}/fonts/Univers LT W01 93 X Black Ext.otf') format('opentype');
+				src: url('${BASE_PATH}/fonts/Univers LT W01 93 X Black Ext.otf') format('opentype');
 			}
       `}
     />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,12 @@
+import { version } from '../../package.json';
+
+// Pathname where App is hosted
+export const BASE_PATH = `/version/${version}`;
+
+// Time
 export const SECOND = 1000;
 export const MINUTE = 60 * SECOND;
 export const HOUR = 60 * MINUTE;
 
+// Intervals
 export const FETCH_RETRY = 30 * SECOND;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
-
+import { global_config } from './config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: global_config.basePath,
   plugins: [
     react(),
     nodePolyfills({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
-import { global_config } from './config';
+
+import { BASE_PATH } from './src/utils/constants';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: global_config.basePath,
+  base: BASE_PATH,
   plugins: [
     react(),
     nodePolyfills({


### PR DESCRIPTION
Changes:
- Create /config.ts which is used for internal app routing
- Update base-path url in vite.config.ts and src/theme/Fonts.tsx
- Add deploy-to-r2 jobs in the gh action release.yaml. Action will trigger on tag (On each tag the cf_redirect_rule must be updated)